### PR TITLE
docs: add v0.1 plan to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ samples/        Known-good sample inputs used by happy-path + failure tests
 - Happy-path test runs through stages Discover → Extract → RecognizeInputFormat → Normalize → Analyze → QuickDraft → Evaluate → Publish.
 - Failure tests: F1 (corrupt PDF), F2 (adapter disagreement), F4 (schema drift), F5 (policy violation), F11 (format miss), F12 (required-section miss).
 
-See `~/.claude/plans/doc-pipeline-engine-init.md` for the full v0.1 design doc.
+See [`docs/plans/v0.1-init.md`](docs/plans/v0.1-init.md) for the full v0.1 design doc.
 
 ## Quickstart
 

--- a/docs/plans/v0.1-init.md
+++ b/docs/plans/v0.1-init.md
@@ -1,0 +1,565 @@
+# Plan: Modular Document Processing Pipeline — v0.1 Draft
+
+## Context
+
+The user wants a **modular, extensible, bespoke-per-domain document processing pipeline** that:
+
+- Ingests documents from potentially **unsorted, cluttered folder structures**
+- Optionally **sorts/classifies** files first (optional stage)
+- Mandatorily **analyzes** content and produces:
+  - A **quick concise draft document** (always)
+  - A **comprehensive document** (on demand by user/system)
+- Starts with **PDF, DOCX, XLSX, TXT/MD, images**; plans for CAD/LOB later
+- Targets use cases: **mechanical/electrical, certification/standards, medical/research, patents**
+- Makes **data protection and security key**
+- Uses **Claude Code CLI as the core LLM** initially, with **docling, GLM-OCR, PaddleOCR-VL** as validators / fallbacks / replacements
+- Expects **eval, testing, and eventual certification**
+- Plans for **fine-tuning, graph, RAG, and efficacy metrics** (accuracy, faithfulness, groundedness)
+
+**Why v0.1 now:** agree on architecture, reserve names in `claude-code-plugins/`, stand up scaffolding, prove end-to-end happy path on one sample, and map the failure modes that will drive hardening in v0.2+.
+
+---
+
+## Answers from planning dialogue
+
+| Decision | Choice |
+|---|---|
+| Deliverable | **Hybrid**: new `doc-pipeline` plugin in `claude-code-plugins/plugins/` + standalone `doc-pipeline-engine` repo |
+| Pilot domains | **Generic light pilot first**, include **mech/elec+cert** and **medical/research/patents** as explicit pilot packs |
+| Security posture | **Decide per domain pack** — v0.1 defines the policy *surface* (hooks + config), packs pick local-only / Claude-API / cloud |
+| Orchestration | **Test feasibility of all 4 patterns** (team mode, parallel-workers subagents, hybrid, plain skill chain) to place **deterministic gates** between stages |
+| v0.1 scope | **Happy-path E2E on one sample + scaffolding + reasoning/goals + non-happy failure paths** |
+| File types | **PDF, DOCX, XLSX, TXT/MD, images** |
+| Output tiers | **Combined**: comprehensive = deeper extraction + richer template + formal eval; quick = shallow + short + smoke eval |
+
+---
+
+## Goals / Non-goals
+
+**Goals (v0.1)**
+
+1. A runnable end-to-end happy path on one sample PDF: ingest → (opt) sort → **recognize input format** → extract → analyze → quick draft in **declared output format** → (on demand) comprehensive → eval gate.
+2. Clear **domain-pack** extension point so mech/elec/cert and medical/research/patents can be added without touching the core.
+3. Modular **adapters** so docling / GLM-OCR / PaddleOCR-VL / Claude CLI can be swapped or used concurrently as validators.
+4. **Deterministic gates** between stages with machine-readable contracts (JSON schemas), so any of the 4 orchestration patterns can be swapped in without changing the contract surface.
+5. **Definable input and output formats** — both are pluggable per domain pack (see "Format definability" section below); format recognition on ingest and format conformance on emit are gated.
+6. Scaffolding only where it pays off — plugin + worker repo skeleton, not a full implementation.
+
+**Non-goals (v0.1)**
+
+- CAD / LOB ingest (deferred to v0.3+)
+- Fine-tuning pipeline (v0.3+)
+- Graph-RAG implementation (v0.2; interface reserved in v0.1)
+- Full certification package (v0.4+; document the target frameworks only)
+- Multi-tenant deployment (v0.2+)
+- Production-grade UI (v0.2+; CLI-first in v0.1)
+
+---
+
+## Architecture overview
+
+### Two-surface split
+
+```
+claude-code-plugins/plugins/doc-pipeline/     ← control plane (CC-native)
+  plugin.json, skills/, agents/, hooks/, rules/, commands/
+  (uses rag-core, docs-generator, mas-design, cc-meta, tdd-core)
+
+/workspaces/qte77/doc-pipeline-engine/       ← data plane (heavy workers)
+  workers/docling_adapter/
+  workers/glm_ocr_adapter/
+  workers/paddleocr_vl_adapter/
+  workers/claude_cli_adapter/
+  contracts/  (JSON schemas — the gate format)
+  domains/generic/, domains/mech-elec-cert/, domains/med-research-patents/
+  eval/       (RAGAs, TruLens, DeepEval harnesses)
+  policies/   (per-domain locality/redaction policies)
+  Makefile, pyproject.toml, tests/
+```
+
+**Why split:** the CC plugin owns orchestration, skills, agents, and hooks; the worker repo owns heavy Python dependencies (docling, mlx-vlm, ollama, llama.cpp, sentence-transformers). Separation lets the CC plugin stay lightweight and version-bumpable, while workers evolve on their own release cycle and can be pinned per domain pack.
+
+### Stage graph (deterministic-gate friendly)
+
+```
+[0] Discover          → DiscoveryManifest.json        (files found, hash, type)
+[1] Classify/Sort (opt)→ ClassificationManifest.json  (domain, doc-kind, confidence)
+[2] Extract           → ExtractionBundle.json         (text, layout tree, tables, figures, images)
+[3] Normalize         → CanonicalDoc.json             (structured L0/L1/L2 tree — OpenViking-inspired)
+[4] Analyze           → AnalysisReport.json           (claims, entities, relations, citations)
+[5a] Quick Draft      → quick-draft.md + draft.json   (short, shallow eval)
+[5b] Comprehensive    → comprehensive.md + full eval  (deep extraction, RAG index, formal eval)
+[6] Evaluate          → EvalReport.json               (gate verdict: pass/warn/fail)
+[7] Publish           → release/ (versioned, signed manifest)
+```
+
+Each arrow is a **deterministic gate**: a JSON schema + validator. A gate can reject on schema violation, confidence threshold, eval score, or policy violation. Gates are uniform across all 4 orchestration patterns.
+
+### Core abstractions
+
+| Abstraction | Purpose | Notes |
+|---|---|---|
+| `Source` | Ingest root (folder, URL, repo) | v0.1: local folder only |
+| `DomainPack` | Packaged config: locality policy + prompts + eval thresholds + output templates | e.g. `generic`, `mech-elec-cert`, `med-research-patents` |
+| `Adapter` | Worker binding (docling, GLM-OCR, PaddleOCR-VL, Claude CLI) with uniform input/output schema | Adapters are swappable via adapter registry |
+| `Gate` | Named contract + validator between stages | Rejects on schema / confidence / policy |
+| `Policy` | Data-locality + redaction rules | `local-only`, `claude-api-extracted-only`, `cloud-redacted` |
+| `Evaluator` | RAGAs/TruLens/DeepEval wrapper; produces `EvalReport` | Shared across output tiers |
+| `InputFormat` | Declarative spec for a recognized input shape (schema + heuristics + required fields) | e.g. `ieee-paper`, `iec-60601-section`, `patent-uspto-grant`, `company-spec-v3` |
+| `OutputFormat` | Declarative spec for a required output shape (template + schema + renderer) | e.g. `imrad-markdown`, `iso-9001-audit-report`, `fda-510k-summary`, `adr-madr` |
+| `FormatRegistry` | Maps file-type × domain pack → candidate InputFormats; maps output request → OutputFormat | Both registries are pack-extensible |
+
+---
+
+## Orchestration — four patterns as experiments
+
+The user wants all four tested so deterministic gates can be placed where they best buy reliability. Each pattern runs the same stage graph above; they differ in **who runs each stage** and **how errors surface**.
+
+| Pattern | How | Best-suited stages | Gate placement |
+|---|---|---|---|
+| **P1: Plain skill chain** (baseline) | `ingest` → `extract` → `analyze` → `draft` skills invoked sequentially | Sort, quick-draft tier | After every stage (cheapest to verify) |
+| **P2: Subagents via `orchestrating-parallel-workers`** | Lead fans out per-document extraction / per-chunk analysis | Extract (per-file parallel), analyze (per-chunk parallel) | Gate on join (fan-in) |
+| **P3: Team mode (lead + teammates)** | Lead = orchestrator; teammates = ingest, extract, analyze, draft, review, eval agents with worktree isolation | Comprehensive tier, multi-domain runs | Gate at teammate handoff |
+| **P4: Hybrid** | Team mode for top-level phases; each teammate uses parallel-workers for per-doc fan-out | Production-scale | Gates at both levels (two-layer) |
+
+**Feasibility harness**: `/eval/orchestration-bench/` runs the same 3-document corpus through P1→P4 and records latency, token cost, gate-rejection rate, and drift. This directly answers *"where do deterministic gates belong"* — the gates that consistently catch errors across all 4 patterns become mandatory; others become advisory.
+
+---
+
+## File-type handlers (v0.1 adapters)
+
+| Type | Primary adapter | Validator / fallback |
+|---|---|---|
+| PDF | `docling` (layout + tables + figures) | GLM-OCR / PaddleOCR-VL cross-check; Claude CLI as tie-breaker |
+| DOCX | Anthropic built-in docx skill | `python-docx` fallback |
+| XLSX | Anthropic built-in xlsx skill | `openpyxl` fallback |
+| TXT/MD | native read | none needed |
+| Images | **GLM-OCR-0.9B** primary (OmniDocBench #1, MIT) | PaddleOCR-VL-0.9B (Apache-2.0) for cross-validation; Qwen2.5-VL-3B as third opinion |
+
+Every adapter emits the same `ExtractionBundle.json` schema. Cross-validation produces a `ConfidenceReport` — the gate `G_extract` rejects if two adapters disagree above threshold τ (defaults differ per domain pack).
+
+> **File-type vs Format**: file-type is the container (PDF, DOCX, ...). **Format** is the *shape* of the content inside — e.g. an IEEE paper PDF, an IEC 60601 section PDF, and a USPTO patent PDF are all PDFs but three different *input formats*. Format handling is covered in the next section.
+
+---
+
+## Input / Output format definability
+
+Both input and output formats are **first-class, pluggable objects** defined per domain pack. The pipeline does not hard-code any format — formats live in `domains/<pack>/input_formats/` and `domains/<pack>/output_formats/` and are discovered via a registry at load time.
+
+### Input format: declarative spec
+
+An `InputFormat` is a folder with a manifest declaring:
+
+```
+domains/<pack>/input_formats/<format-id>/
+  format.json          # id, version, file-type(s), matchers, required fields, provenance
+  schema.json          # JSON schema the ExtractionBundle must conform to for this format
+  matchers/            # heuristic + deterministic matchers (regex, layout fingerprints, header patterns)
+    by_filename.json   # optional: glob/regex hints
+    by_metadata.json   # optional: PDF metadata / docinfo matchers
+    by_layout.yaml     # structural matchers on CanonicalDoc (L0/L1 section tree)
+    by_content.yaml    # anchor phrases ("Abstract", "1. Introduction", "Claims:")
+  example/             # one known-good sample (for tests)
+  README.md
+```
+
+**How it's used**:
+
+- After extraction, the `RecognizeInputFormat` stage queries the registry and runs matchers → emits `FormatMatch.json` (candidate format + confidence + evidence).
+- **Gate `G_format_in`**: if no match ≥ τ_match, the document routes to the **generic** format path (graceful degrade, not failure). If a pack requires a strict format (`"strict": true`), the gate rejects on miss.
+- Matched format's `schema.json` is cross-validated against the `ExtractionBundle` — missing required fields flagged in `AnalysisReport`.
+
+### Output format: declarative spec
+
+An `OutputFormat` is a folder with a manifest declaring:
+
+```
+domains/<pack>/output_formats/<format-id>/
+  format.json          # id, version, tier (quick|comprehensive|both), renderer, required sections
+  schema.json          # JSON schema the rendered output's frontmatter + structure must satisfy
+  template.{md,jinja,docx,xlsx}   # the actual template — multi-renderer support
+  renderer.py          # (optional) custom renderer; defaults to jinja2 + pandoc
+  citation_style.json  # IEEE | APA | Chicago | Vancouver | domain-specific
+  required_sections.yaml   # ordered list with presence rules
+  example/             # one reference output (for golden-file tests)
+  README.md
+```
+
+**How it's used**:
+
+- The pipeline call signature is `run(source, pack, policy, tier, output_format=<id>)`. If `output_format` is omitted, the pack picks its default.
+- Drafting skills (`generating-doc-quick-draft` / `generating-doc-comprehensive`) load the `OutputFormat`, render via the declared renderer, and emit both the rendered document and a `FormatConformance.json` report.
+- **Gate `G_format_out`**: validates rendered output against `schema.json` + `required_sections.yaml`. Missing required sections = `fail`. Style/tone violations caught by eval stage, not gate.
+
+### Format registry
+
+`workers/base/format_registry.py` (wired in v0.1) loads all `format.json` files under every enabled domain pack at startup. Packs may depend on other packs' formats via `extends: <pack>/<format-id>` in `format.json` — enables `mech-elec-cert/iec-60601-report` to extend `generic/technical-report`.
+
+### v0.1 concrete formats (shipped)
+
+| Format | Direction | Pack | Status in v0.1 |
+|---|---|---|---|
+| `generic/any-document` | input | generic | Fully wired — permissive matcher, falls back for unrecognized inputs |
+| `generic/ieee-paper` | input | generic | Matchers + schema wired; used for F11 test |
+| `generic/technical-report-md` | output (quick) | generic | Template + renderer wired — the happy-path output |
+| `generic/imrad-writeup-md` | output (comprehensive) | generic | Template wired; renderer uses `generating-writeup` skill |
+| `generic/adr-madr` | output (comprehensive) | generic | Template wired; uses `generating-tech-spec` skill |
+| `mech-elec-cert/iec-60601-report` | output | mech-elec-cert | Stub (format.json only, no template) — declared for v0.2 |
+| `med-research-patents/fda-510k-summary` | output | med-research-patents | Stub — declared for v0.2 |
+| `med-research-patents/uspto-patent-grant` | input | med-research-patents | Stub — declared for v0.2 |
+
+### CLI surface
+
+```
+/doc-pipeline list-formats --direction in --pack <pack>
+/doc-pipeline list-formats --direction out --pack <pack>
+/doc-pipeline run --source <path> --pack generic --policy claude-api-extracted-only --tier quick --output-format generic/technical-report-md
+/doc-pipeline run --source <path> --pack generic --tier comprehensive --output-format generic/imrad-writeup-md
+```
+
+### Why pluggable formats matter
+
+- **Certification path**: regulated outputs (FDA 510(k), IEC 62304 SOUP, ISO 9001 audit report) are defined *before* implementation — the audit trail can point to a signed `format.json` that was in force on the run date.
+- **Multi-tenant / company templates**: each customer can ship a `company-spec-v3` input format and a `company-brief-v1` output format without forking the pipeline.
+- **Evolvability**: versioned formats (`format.json` carries `version`) let old runs be reproduced with their original format. Breaking format changes get a new id (`ieee-paper-v2`).
+
+---
+
+## Quick draft vs Comprehensive (three-way delta)
+
+| Tier | Extraction depth | Template | Eval rigor |
+|---|---|---|---|
+| **Quick** | Headings + key claims + top-5 entities | 1-page Markdown summary via `generating-report` | Smoke eval only (schema + 1 faithfulness check) |
+| **Comprehensive** | Full canonical tree + RAG index + tables/figures/citations/cross-refs | IMRaD / tech-spec via `generating-writeup` + `generating-tech-spec` | RAGAs (context precision/recall, faithfulness) + TruLens RAG triad + human-in-loop review gate |
+
+Always produce quick draft first — it also doubles as the executive summary inside the comprehensive output.
+
+---
+
+## "AST/treesitter/code-review-graph for documents?" — direct answer
+
+**Short answer:** Yes — conceptually and practically, with caveats.
+
+- **Not treesitter itself**: treesitter is grammar-driven for formal languages; document prose has no grammar.
+- **But document-layout ASTs exist** — and we're using them:
+  - **Docling** emits a structured layout tree (pages → blocks → tables/figures/text runs) — this is effectively a doc-AST.
+  - **OpenViking**'s L0/L1/L2 tiered tree (analyzed in ai-agents-research/docs/non-cc/openviking-analysis.md) is a document-content-tree with 80% token-reduction over flat RAG.
+  - **PaddleOCR-VL / GOT-OCR2** emit LaTeX/markup that is itself tree-shaped.
+- **Doc-graph = feasible**: nodes = headings/claims/tables/figures/entities; edges = citation, cross-ref, contains, supports/contradicts. This is exactly what AGFS (OpenViking) and PaperQA2 do internally.
+- **Code-review-graph analogue**: a "doc-review-graph" over the `CanonicalDoc.json` + `AnalysisReport.json` — used by the comprehensive eval tier to surface dangling claims, missing citations, contradictions across documents. Reserve the interface in v0.1, implement in v0.2.
+
+**v0.1 concrete step**: define `CanonicalDoc.json` schema as a layout+content tree (directly consumable by RAG and the future doc-graph). This is the single most load-bearing contract in the pipeline.
+
+---
+
+## Security / data-protection surface (v0.1 defines, packs decide)
+
+Three named policies shipped as presets:
+
+1. `local-only` — no outbound API calls; Ollama + llama.cpp + local docling only. Hook `PreToolUse` blocks `WebFetch`, `mcp__*`, and Claude API calls.
+2. `claude-api-extracted-only` — raw documents stay on disk; only extracted chunks (post-redaction) are sent to Claude. Redaction adapter mandatory.
+3. `cloud-redacted` — cloud OCR allowed with PII redaction + audit log. Uses `securing-mas` (MAESTRO) + `detecting-secrets` + `scanning-dependencies` + audit-trail hook.
+
+Each domain pack's `pack.json` declares which policy it defaults to. The `PreToolUse` hook enforces it; violating tool calls are blocked and logged.
+
+Certification-readiness (documented, not implemented in v0.1): target frameworks per domain — ISO 13485 + IEC 62304 (medical), IEC 62443 (industrial), 21 CFR Part 11 (FDA), GDPR, HIPAA. Design decisions noted in ADRs so the audit path exists.
+
+---
+
+## Skills / rules / agents reuse map
+
+**From `claude-code-plugins/`:**
+
+- Plugins: `rag-core`, `docs-generator`, `docs-governance`, `mas-design`, `cc-meta`, `tdd-core`, `security-audit`, `planning`, `codebase-tools`, `python-dev`
+- Skills to invoke:
+  - `implementing-document-indexing` (rag-core) → extraction + RAG index
+  - `generating-writeup`, `generating-report`, `generating-tech-spec` (docs-generator) → output tiers
+  - `designing-mas-plugins`, `securing-mas` (mas-design) → plugin skeleton + MAESTRO threat model
+  - `orchestrating-parallel-workers` (cc-meta) → P2/P4 orchestration
+  - `compacting-context`, `researching-codebase`, `synthesizing-cc-bigpicture` (cc-meta)
+  - `testing-tdd`, `testing-python` (tdd-core, python-dev) → test-first build
+  - `auditing-code-security`, `detecting-secrets`, `scanning-dependencies`, `hardening-codebase` (security-audit, codebase-tools)
+  - `enforcing-doc-hierarchy`, `maintaining-agents-md` (docs-governance)
+- Rules (loaded automatically): `core-principles`, `context-management`, `compound-learning`, `plugin-versioning`, `skill-authoring`
+- Agents: `planner` (planning), `build-error-resolver` (codebase-tools)
+
+**New skills in `doc-pipeline` plugin (frontmatters in v0.1, content in v0.2):**
+
+- `ingesting-unsorted-folders` — discovery + dedup + hash manifest
+- `classifying-document-domain` — optional sort stage
+- `extracting-document-with-adapters` — multi-adapter cross-validation
+- `recognizing-input-format` — match ExtractionBundle against InputFormat registry
+- `canonicalizing-document-tree` — build `CanonicalDoc.json` (format-aware)
+- `analyzing-document-claims` — claims/entities/relations extraction
+- `generating-doc-quick-draft` — short output against declared OutputFormat
+- `generating-doc-comprehensive` — long-form output against declared OutputFormat (w/ citations)
+- `rendering-output-format` — shared renderer (jinja/pandoc/docx/xlsx) used by both draft skills
+- `gating-pipeline-stage` — deterministic-gate validator (shared helper)
+- `evaluating-doc-output` — RAGAs/TruLens/DeepEval harness wrapper
+- `authoring-input-format` — scaffolder for new InputFormat folders (helps pack authors)
+- `authoring-output-format` — scaffolder for new OutputFormat folders (helps pack authors)
+
+**New agents:**
+
+- `doc-pipeline-lead` (opus) — P3/P4 orchestrator
+- `doc-extractor` (sonnet) — P2/P4 fan-out worker
+- `doc-reviewer` (opus) — comprehensive eval gate
+
+**New rules (plugin-local):**
+
+- `adapter-contract.md` — every adapter must emit `ExtractionBundle.json`; no exceptions
+- `domain-pack-contract.md` — pack declares policy + prompts + thresholds + input_formats + output_formats
+- `format-contract.md` — every InputFormat/OutputFormat carries `id`, `version`, schema, example; breaking changes bump id, not version
+- `gate-before-next-stage.md` — never skip a gate
+
+---
+
+## Directory / file layout (to scaffold in v0.1)
+
+```
+claude-code-plugins/plugins/doc-pipeline/
+  plugin.json
+  .claude-plugin/marketplace.json
+  skills/
+    ingesting-unsorted-folders/SKILL.md              (frontmatter only in v0.1)
+    classifying-document-domain/SKILL.md
+    extracting-document-with-adapters/SKILL.md
+    canonicalizing-document-tree/SKILL.md
+    analyzing-document-claims/SKILL.md
+    generating-doc-quick-draft/SKILL.md
+    generating-doc-comprehensive/SKILL.md
+    gating-pipeline-stage/SKILL.md
+    evaluating-doc-output/SKILL.md
+  agents/
+    doc-pipeline-lead.md
+    doc-extractor.md
+    doc-reviewer.md
+  hooks/
+    hooks.json                                       (SessionStart policy + PreToolUse enforcement)
+    enforce-policy.sh
+    setup-doc-pipeline.sh
+  rules/
+    adapter-contract.md
+    domain-pack-contract.md
+    gate-before-next-stage.md
+  commands/
+    doc-pipeline.md                                  (slash command entry point)
+  AGENTS.md, AGENT_REQUESTS.md, AGENT_LEARNINGS.md, README.md
+
+/workspaces/qte77/doc-pipeline-engine/
+  README.md, Makefile, pyproject.toml, .gitignore
+  contracts/
+    DiscoveryManifest.schema.json
+    ClassificationManifest.schema.json
+    ExtractionBundle.schema.json
+    CanonicalDoc.schema.json
+    AnalysisReport.schema.json
+    EvalReport.schema.json
+    FormatMatch.schema.json           # recognized input format + confidence
+    FormatConformance.schema.json     # output conformance to declared OutputFormat
+    InputFormat.schema.json           # meta-schema for format.json (input side)
+    OutputFormat.schema.json          # meta-schema for format.json (output side)
+  workers/
+    base/adapter.py                                  (Adapter ABC)
+    docling_adapter/                                 (stub)
+    glm_ocr_adapter/                                 (stub)
+    paddleocr_vl_adapter/                            (stub)
+    claude_cli_adapter/                              (stub — the "core" cli path)
+  domains/
+    generic/
+      pack.json + prompts/ + thresholds.json
+      input_formats/
+        any-document/           (wired — permissive fallback)
+        ieee-paper/             (wired — used for F11)
+      output_formats/
+        technical-report-md/    (wired — quick tier happy path)
+        imrad-writeup-md/       (wired — comprehensive tier)
+        adr-madr/               (wired — alt comprehensive tier)
+    mech-elec-cert/
+      pack.json (stub)
+      output_formats/iec-60601-report/   (stub: format.json only)
+    med-research-patents/
+      pack.json (stub)
+      input_formats/uspto-patent-grant/  (stub)
+      output_formats/fda-510k-summary/   (stub)
+  policies/
+    local-only.json
+    claude-api-extracted-only.json
+    cloud-redacted.json
+  eval/
+    ragas_harness.py (stub)
+    trulens_harness.py (stub)
+    deepeval_harness.py (stub)
+    orchestration-bench/
+      run_p1.py, run_p2.py, run_p3.py, run_p4.py     (stubs + README explaining the feasibility harness)
+  tests/
+    test_contracts.py                                (schema round-trip — fully wired in v0.1)
+    test_happy_path.py                               (fully wired for one sample PDF)
+    test_failure_paths.py                            (non-happy cases below)
+  samples/
+    generic/sample.pdf                               (one sample — any small PDF)
+```
+
+Only **`tests/test_contracts.py`**, **`tests/test_happy_path.py`**, **`tests/test_failure_paths.py`**, the **contracts/** JSON schemas, the **generic domain pack**, one adapter (docling OR claude_cli — TBD at scaffolding time based on simpler install), and the **gate validator** are fully wired in v0.1. Everything else is stubs + frontmatter + README.
+
+---
+
+## Happy path walkthrough (v0.1 E2E target)
+
+Input: one generic sample PDF in `samples/generic/sample.pdf`, domain pack `generic`, policy `claude-api-extracted-only`.
+
+Input: one generic sample PDF in `samples/generic/sample.pdf`, domain pack `generic`, policy `claude-api-extracted-only`, output format `generic/technical-report-md`.
+
+1. **Discover** — scan folder, emit `DiscoveryManifest.json` with SHA-256 per file.
+2. **Classify (opt, skipped for sample)** — stub returns `domain: generic, confidence: 1.0`.
+3. **Extract** — docling OR claude_cli adapter runs; emit `ExtractionBundle.json` (text + layout tree + tables).
+4. **Gate `G_extract`** — validate schema; check confidence ≥ 0.7. Pass.
+5. **Recognize input format** — registry runs matchers for pack `generic` → emits `FormatMatch.json`. Happy path matches `generic/ieee-paper`; unknowns fall back to `generic/any-document`.
+6. **Gate `G_format_in`** — in permissive mode, always passes; in strict mode (pack-declared), rejects on no match.
+7. **Normalize** — build `CanonicalDoc.json` (L0/L1/L2 tree) using format-aware heuristics (recognized format may promote specific sections).
+8. **Analyze** — extract claims, entities, top-5 citations; emit `AnalysisReport.json`.
+9. **Gate `G_analyze`** — schema + sanity checks (≥1 claim, ≥1 heading).
+10. **Load OutputFormat** — `generic/technical-report-md` → template + schema + required sections.
+11. **Quick Draft** — render via declared renderer (jinja2 template) against `AnalysisReport` + `CanonicalDoc`.
+12. **Gate `G_format_out`** — validate rendered output against `OutputFormat.schema.json` + `required_sections.yaml`.
+13. **Evaluate (smoke)** — schema + 1 faithfulness check via DeepEval stub; emit `FormatConformance.json` + `EvalReport.json`.
+14. **Gate `G_eval`** — pass/warn/fail.
+15. **Publish** — `release/v0.1.0/sample/quick-draft.md` + signed manifest (records input-format id + output-format id + versions).
+
+Orchestration: run via **P1 (plain skill chain)** for the demo; the same steps are also runnable via the P2/P3/P4 entry points (stubbed) to prove the contracts are orchestration-agnostic.
+
+---
+
+## Non-happy failure paths (must be documented in v0.1; some wired as tests)
+
+| # | Scenario | Stage | Expected behavior |
+|---|---|---|---|
+| F1 | Corrupt / password-protected PDF | Extract | Adapter returns `ExtractionError`; gate `G_extract` fails closed; pipeline halts with actionable message. **Test wired.** |
+| F2 | Two adapters disagree > τ on same page | Extract | `ConfidenceReport` flags divergence; gate `G_extract` returns `warn`; falls back to third adapter (Claude CLI) as tie-breaker. **Test wired (synthetic disagreement).** |
+| F3 | OCR pass emits empty text for image PDF | Extract | Detected by min-token-count check; retry with GLM-OCR; if still empty, halt with "image-only PDF requires OCR pack" error. |
+| F4 | Schema drift (adapter emits extra/missing field) | Any gate | JSON-schema validator rejects; pipeline halts; logs offending field. **Test wired.** |
+| F5 | Policy violation (local-only pack tries Claude API) | Any | `PreToolUse` hook blocks tool; hook writes to audit log. **Test wired.** |
+| F6 | RAGAs faithfulness < threshold on comprehensive tier | Evaluate | Gate `G_eval` returns `fail`; draft marked `needs-review`; never published to release/. |
+| F7 | Classifier misrouts document (medical → mech-elec) | Classify | Low confidence triggers `classification-review` queue; human-in-loop gate required for comprehensive tier. |
+| F8 | Infinite loop / stalled subagent (P2/P3/P4) | Orchestration | Timeout at the gate; cc-meta's context-compaction runs; lead kills teammate and retries once, then fails. |
+| F9 | PII leak detected in draft | Quick/Comprehensive | Redaction adapter catches pre-publish; gate blocks publish; incident logged. |
+| F10 | Disk-hash mismatch on re-run (source mutated) | Discover | Treat as new version; re-run full pipeline; mark prior release superseded. |
+| F11 | Input doesn't match any declared InputFormat (strict pack) | Recognize | `G_format_in` rejects with list of attempted matchers + closest candidate. Permissive packs fall back to `generic/any-document` with warning. **Test wired (strict pack + off-template input).** |
+| F12 | Rendered output misses a required section | Render | `G_format_out` rejects; renderer returns partial output to audit log; pipeline halts before publish. **Test wired (template with deliberately blanked required section).** |
+| F13 | Output format version is higher than pack supports | Load OutputFormat | Hard fail at load-time with clear "pack version N supports format version ≤M" message. |
+| F14 | Input format matcher has false positive (wrong format recognized) | Recognize | Confidence threshold + evidence log in `FormatMatch.json`; eval stage catches downstream (wrong sections in output); gate `G_eval` fails. |
+
+F1, F2, F4, F5, F11, F12 wired as executable tests in v0.1. Others documented in `failure-modes.md` for v0.2 test harness.
+
+---
+
+## Evaluation & metrics plan
+
+- **v0.1**: smoke eval only (schema + 1 faithfulness via DeepEval).
+- **v0.2**: RAGAs (context precision/recall, faithfulness, relevancy) + TruLens RAG triad.
+- **v0.3**: HELM-style multi-metric (accuracy, calibration, robustness, bias, fairness) per domain pack.
+- **Certification track**: log every run under `release/<version>/audit/` with inputs, outputs, model IDs, adapter versions, gate verdicts, policy in force, timestamps — establishes the audit trail eventual certification will require.
+
+---
+
+## Critical files to create (paths)
+
+**New in `claude-code-plugins/plugins/doc-pipeline/`** — every file listed in "Directory / file layout" above. All skills and agents in v0.1 are frontmatter + 1-paragraph intent + references; bodies in v0.2.
+
+**New in `/workspaces/qte77/doc-pipeline-engine/`** — every file listed in "Directory / file layout" above. Fully wired in v0.1: `contracts/*.schema.json`, `domains/generic/*`, `policies/local-only.json` + `claude-api-extracted-only.json`, one adapter, `tests/test_contracts.py`, `tests/test_happy_path.py`, `tests/test_failure_paths.py` (F1, F2, F4, F5), `samples/generic/sample.pdf`, `Makefile`, `pyproject.toml`.
+
+**Update in `claude-code-plugins/`:**
+
+- `.claude-plugin/marketplace.json` — register `doc-pipeline` plugin
+- `AGENT_REQUESTS.md` — log 2 open decisions (see below)
+
+---
+
+## Reused functions / utilities (do not re-implement)
+
+| Need | Reuse |
+|---|---|
+| Heading-boundary chunking + FAISS index | `rag-core/skills/implementing-document-indexing/` |
+| Pandoc PDF export of comprehensive tier | `docs-generator/skills/generating-writeup/` |
+| ADR/RFC scaffolding for design decisions | `docs-generator/skills/generating-tech-spec/` |
+| Parallel worker fan-out (P2, P4) | `cc-meta/skills/orchestrating-parallel-workers/` |
+| Context compaction between stages | `cc-meta/skills/compacting-context/` |
+| OWASP MAESTRO threat model | `mas-design/skills/securing-mas/` |
+| Plugin skeleton generator | `mas-design/skills/designing-mas-plugins/` |
+| TDD pytest harness | `tdd-core/skills/testing-tdd/` + `python-dev/skills/testing-python/` |
+| Security audit hooks | `security-audit/skills/auditing-code-security/` + `detecting-secrets/` + `scanning-dependencies/` |
+| Doc governance guardrails | `docs-governance/skills/enforcing-doc-hierarchy/` + `maintaining-agents-md/` |
+| Pre-implementation research | `codebase-tools/skills/researching-codebase/` |
+| Feature planning | `planning/agents/planner` |
+| Codebase hardening | `codebase-tools/skills/hardening-codebase/` (for v0.2 audit) |
+
+---
+
+## Verification section
+
+After scaffolding, the following must all pass:
+
+```bash
+# 1. Plugin is registered and discoverable
+cd /workspaces/qte77/claude-code-plugins
+grep doc-pipeline .claude-plugin/marketplace.json
+
+# 2. Plugin CI passes
+gh workflow run check-plugin-versions.yml
+gh workflow run check-skill-integrity.yml
+
+# 3. Worker repo contract tests pass (schema round-trips)
+cd /workspaces/qte77/doc-pipeline-engine
+make test-contracts
+
+# 4. Happy-path E2E on sample PDF
+make happy-path        # runs P1 chain end-to-end; produces release/v0.1.0/sample/quick-draft.md
+
+# 5. Non-happy failure tests
+make test-failure      # F1, F2, F4, F5 all fail closed with correct error codes
+
+# 6. Policy-enforcement hook fires
+#    (local-only pack + attempted WebFetch → blocked with audit log entry)
+make test-policy-local-only
+
+# 7. Orchestration feasibility bench (stubs only in v0.1 — just confirms entry points exist)
+make orch-bench-dryrun
+```
+
+Manual verification:
+
+- Open `release/v0.1.0/sample/quick-draft.md` — should be a 1-page coherent summary with headings + key claims + metadata block.
+- Open `release/v0.1.0/sample/audit/run.json` — should contain inputs, adapter versions, gate verdicts, policy, timestamps.
+- Run the CC slash command `/doc-pipeline run --source samples/generic --pack generic --policy claude-api-extracted-only --tier quick` and verify the same output.
+
+---
+
+## Work breakdown (phases within v0.1)
+
+1. **Contracts first** — write all 10 JSON schemas (6 stage contracts + 4 format contracts); wire `test_contracts.py`.
+2. **Format registry** — `workers/base/format_registry.py` + meta-schemas (`InputFormat.schema.json`, `OutputFormat.schema.json`).
+3. **Plugin skeleton** — invoke `designing-mas-plugins` to scaffold `doc-pipeline` plugin; frontmatters only for skills.
+4. **Worker repo init** — pyproject.toml, Makefile, one adapter (start with `claude_cli_adapter` — zero install overhead).
+5. **Generic domain pack + policies + formats** — two policies (`local-only`, `claude-api-extracted-only`); generic pack.json + 2 input formats (`any-document`, `ieee-paper`) + 3 output formats (`technical-report-md`, `imrad-writeup-md`, `adr-madr`).
+6. **Gate validator** — single shared helper covering both stage gates and format gates in workers/base.
+7. **Happy path** — wire stages 0→11 on one sample PDF via P1 with explicit `--output-format generic/technical-report-md`.
+8. **Failure tests** — F1, F2, F4, F5, **F11**, **F12**.
+9. **Hooks** — `PreToolUse` policy enforcement.
+10. **Docs** — README in each repo + ADR-0001 "two-surface split" + ADR-0002 "deterministic-gate contract-first" + ADR-0003 "format definability (InputFormat/OutputFormat)" + `failure-modes.md`.
+11. **AGENT_REQUESTS entries** — see Open questions.
+
+---
+
+## Open questions deferred to implementation time (logged in AGENT_REQUESTS)
+
+1. **First wired adapter: docling vs claude_cli?** — claude_cli is the stated core and zero-install; docling proves the multi-adapter contract earlier. Recommendation: claude_cli first for happy path, docling second for F2 cross-validation test.
+2. **Signing format for release manifests** — sigstore / GPG / SHA-only. Recommendation: SHA-only for v0.1, sigstore for v0.2. Signed manifest records input-format id/version and output-format id/version to support reproducibility + audit.
+3. **Doc-graph runtime** — reserve schema in v0.1 but don't implement; evaluate Neo4j vs NetworkX vs AGFS-style file graph in v0.2.
+4. **Renderer set for v0.1** — jinja2+markdown is minimum; pandoc for PDF/DOCX comprehensive output; openpyxl for XLSX outputs. Recommendation: jinja+markdown only in v0.1; add pandoc in v0.2 when comprehensive tier is wired.
+5. **Strict vs permissive input-format matching default** — per-pack decision. Recommendation: `generic` pack permissive (falls back to `any-document`); regulated packs (`mech-elec-cert`, `med-research-patents`) strict.
+
+---
+
+## Conversation name
+
+`doc-pipeline-modular-draft` (full: *Modular Document Processing Pipeline — v0.1 Plan*)


### PR DESCRIPTION
## Summary
- Move v0.1 plan from `~/.claude/plans/` into `docs/plans/v0.1-init.md`
- Update README to reference in-repo plan

## Test plan
- [ ] Link in README resolves

Generated with Claude <noreply@anthropic.com>