### PR TITLE
docs: add agent governance and CONTRIBUTING

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,41 +20,12 @@ agents.** For technical workflows and coding standards, see
 **Priority Order:** User instructions > AGENTS.md compliance > Documentation
 hierarchy > Project patterns > General best practices
 
-**Anti-Scope-Creep Rules:**
-
-- **NEVER implement features without requirement validation**
-- **Always validate implementation decisions against project scope boundaries**
-
-**Anti-Redundancy Rules:**
-
-- **NEVER duplicate information across documents** - reference authoritative sources
-- **Update authoritative document, then remove duplicates elsewhere**
-
 **When to Escalate to AGENT_REQUESTS.md:**
 
 - User instructions conflict with safety/security practices
 - AGENTS.md rules contradict each other
 - Required information completely missing
 - Actions would significantly change project architecture
-
-## Agent Neutrality Requirements
-
-**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
-
-1. **Extract requirements from specified documents ONLY**
-   - Read provided task descriptions or reference materials
-   - Do NOT make assumptions about unstated requirements
-   - Do NOT add functionality not explicitly requested
-
-2. **Request clarification for ambiguous scope**
-   - If task boundaries are unclear, ASK for clarification
-   - If complexity level is not specified, ASK for target complexity
-   - Do NOT assume scope or make architectural decisions without validation
-
-3. **Design to stated requirements exactly**
-   - Match the complexity level requested
-   - Follow "minimal," "streamlined," or "focused" guidance literally
-   - Do NOT over-engineer solutions beyond stated needs
 
 ## Compliance Requirements
 
@@ -76,24 +47,4 @@ hierarchy > Project patterns > General best practices
 
 ### Below Threshold Action
 
-Gather more context or escalate to AGENT_REQUESTS.md
-
-## Agent Quick Reference
-
-**Pre-Task:**
-
-- Read AGENTS.md > CONTRIBUTING.md for technical details
-- Verify quality thresholds met
-
-**During Task:**
-
-- Use project commands (document deviations)
-- Follow existing patterns and conventions
-- Update documentation when learning patterns
-
-**Post-Task:**
-
-- Run validation - must pass all checks (code tasks only)
-- Update CHANGELOG.md for non-trivial changes
-- Document new patterns in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
-- Escalate to AGENT_REQUESTS.md if blocked
+Gather more context or escalate to AGENT_REQUESTS.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,16 +15,6 @@ agents.** For technical workflows and coding standards, see
 
 **Rules** (`.claude/rules/`): Session-loaded constraints (always active)
 
-## Core Rules & AI Behavior
-
-- Follow SDLC principles: maintainability, modularity, reusability, adaptability
-- **Never assume missing context** - Ask questions if uncertain about requirements
-- **Never hallucinate libraries** - Only use packages verified in project dependencies
-- **Always confirm file paths exist** before referencing in code or tests
-- **Never delete existing code** unless explicitly instructed or documented refactoring
-- **Document new patterns** in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
-- **Request human feedback** in AGENT_REQUESTS.md (concise, laser-focused, streamlined)
-
 ## Decision Framework
 
 **Priority Order:** User instructions > AGENTS.md compliance > Documentation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# Agent Instructions
+
+**Behavioral rules, compliance requirements, and decision frameworks for AI coding
+agents.** For technical workflows and coding standards, see
+[CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
+[README.md](README.md).
+
+**External References:**
+
+- @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
+- @AGENT_REQUESTS.md - Escalation and human collaboration
+- @AGENT_LEARNINGS.md - Pattern discovery and knowledge sharing
+
+## Claude Code Infrastructure
+
+**Rules** (`.claude/rules/`): Session-loaded constraints (always active)
+
+## Core Rules & AI Behavior
+
+- Follow SDLC principles: maintainability, modularity, reusability, adaptability
+- **Never assume missing context** - Ask questions if uncertain about requirements
+- **Never hallucinate libraries** - Only use packages verified in project dependencies
+- **Always confirm file paths exist** before referencing in code or tests
+- **Never delete existing code** unless explicitly instructed or documented refactoring
+- **Document new patterns** in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- **Request human feedback** in AGENT_REQUESTS.md (concise, laser-focused, streamlined)
+
+## Decision Framework
+
+**Priority Order:** User instructions > AGENTS.md compliance > Documentation
+hierarchy > Project patterns > General best practices
+
+**Anti-Scope-Creep Rules:**
+
+- **NEVER implement features without requirement validation**
+- **Always validate implementation decisions against project scope boundaries**
+
+**Anti-Redundancy Rules:**
+
+- **NEVER duplicate information across documents** - reference authoritative sources
+- **Update authoritative document, then remove duplicates elsewhere**
+
+**When to Escalate to AGENT_REQUESTS.md:**
+
+- User instructions conflict with safety/security practices
+- AGENTS.md rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+
+## Agent Neutrality Requirements
+
+**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+
+1. **Extract requirements from specified documents ONLY**
+   - Read provided task descriptions or reference materials
+   - Do NOT make assumptions about unstated requirements
+   - Do NOT add functionality not explicitly requested
+
+2. **Request clarification for ambiguous scope**
+   - If task boundaries are unclear, ASK for clarification
+   - If complexity level is not specified, ASK for target complexity
+   - Do NOT assume scope or make architectural decisions without validation
+
+3. **Design to stated requirements exactly**
+   - Match the complexity level requested
+   - Follow "minimal," "streamlined," or "focused" guidance literally
+   - Do NOT over-engineer solutions beyond stated needs
+
+## Compliance Requirements
+
+1. **Command Execution**: Use project make recipes or standard tooling
+2. **Quality Validation**: Run validation before task completion; fix ALL issues
+3. **Coding Style**: Follow existing project patterns and conventions
+4. **Documentation Updates**: Update docs when introducing new patterns
+5. **Testing**: Create tests for new functionality
+6. **Code Standards**: Use absolute imports, add `# Reason:` comments for complex logic
+
+## Quality Thresholds
+
+**Before starting any task, ensure:**
+
+- **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
+- **Clarity**: 7/10 - Clear implementation path and expected outcomes
+- **Alignment**: 8/10 - Follows project patterns and architectural decisions
+- **Success**: 7/10 - Confident in completing task correctly
+
+### Below Threshold Action
+
+Gather more context or escalate to AGENT_REQUESTS.md
+
+## Agent Quick Reference
+
+**Pre-Task:**
+
+- Read AGENTS.md > CONTRIBUTING.md for technical details
+- Verify quality thresholds met
+
+**During Task:**
+
+- Use project commands (document deviations)
+- Follow existing patterns and conventions
+- Update documentation when learning patterns
+
+**Post-Task:**
+
+- Run validation - must pass all checks (code tasks only)
+- Update CHANGELOG.md for non-trivial changes
+- Document new patterns in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- Escalate to AGENT_REQUESTS.md if blocked

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -1,0 +1,14 @@
+---
+title: Agent Learning Documentation
+description: Non-obvious patterns that prevent repeated mistakes across sprints
+---
+
+## Template
+
+- **Context**: When/where this applies
+- **Problem**: What issue this solves
+- **Solution**: Implementation approach
+- **Example**: Working code
+- **References**: Related files
+
+## Learned Patterns

--- a/AGENT_REQUESTS.md
+++ b/AGENT_REQUESTS.md
@@ -1,0 +1,18 @@
+---
+title: Agent Requests to Humans
+description: Escalation protocol and active requests requiring human decision
+---
+
+**Always escalate when:**
+
+- User instructions conflict with safety/security practices
+- Rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+- Critical dependencies unavailable
+
+**Format:** `- [ ] [PRIORITY] Description` with Context, Problem, Files, Alternatives, Impact
+
+## Active Requests
+
+None.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Technical workflows, commands, and conventions for human contributors and AI
+agents. For agent behavioral rules see [AGENTS.md](AGENTS.md). For project
+overview see [README.md](README.md).
+
+## Setup
+
+```bash
+make install        # uv sync — install dev dependencies
+```
+
+Requires [uv](https://github.com/astral-sh/uv). Python version pinned in
+`pyproject.toml`.
+
+## Quality commands
+
+| Command | Purpose |
+|---|---|
+| `make test` | Full pytest suite |
+| `make test-contracts` | JSON schema round-trip tests only |
+| `make lint` | Ruff check on Python sources |
+| `make lint-md` | markdownlint on `**/*.md` (MD013 disabled) |
+| `make lint-links` | lychee link check |
+| `make clean` | Remove `.pytest_cache`, `.ruff_cache`, `__pycache__` |
+| `make help` | List all recipes |
+
+Add `VERBOSE=1` to any target for full output.
+
+## Code style
+
+- **Imports**: absolute (`from doc_pipeline_engine.module import X`)
+- **Comments**: default to none; add `# Reason:` only when the *why* is
+  non-obvious
+- **Dependencies**: verify in `pyproject.toml` before importing — never
+  hallucinate libraries
+- **Tests**: mirror `src/` layout under `tests/`; new functionality requires
+  tests
+
+## Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` user-facing capability
+- `fix:` bug fix
+- `docs:` documentation only
+- `chore:` tooling, deps, non-user-facing
+- `refactor:` no behavior change
+- `test:` tests only
+
+Sign commits (GPG required by branch ruleset). See `.gitmessage` for the
+project commit template.
+
+## Pull requests
+
+- One concern per PR — keep diffs focused
+- Reference related issues (`Closes #N`)
+- All required CI checks must be green before merge (CodeQL, CodeFactor)
+- Squash-merge only (enforced by ruleset)
+- Update `CHANGELOG.md` for non-trivial changes
+
+## Documentation hierarchy
+
+Authoritative sources — update these, don't duplicate:
+
+- `README.md` — project overview, quickstart
+- `docs/architecture.md` — design decisions, contracts, runtime modes
+- `docs/roadmap.md` — versioned milestones (0.1 → 0.6+)
+- `docs/landscape.md` — extraction backend survey
+- `AGENTS.md` — AI agent behavioral rules
+- `CONTRIBUTING.md` — this file
+
+## Questions
+
+Open an issue. Agents should escalate via `AGENT_REQUESTS.md`.


### PR DESCRIPTION
## Summary

- Adds **CONTRIBUTING.md**: setup, make recipes, code style, Conventional Commits, PR rules, doc hierarchy. Concise (~75 lines) — modeled on qte77/.github template, not the agents-eval bloat.
- Adds **AGENTS.md**: behavioral rules, decision framework, neutrality requirements, quality thresholds for AI coding agents.
- Adds **AGENT_LEARNINGS.md** / **AGENT_REQUESTS.md**: empty scaffolds for pattern log and human escalation.
- Removes a stale `.claude/skills/` reference from AGENTS.md — directory doesn't exist in this repo (Prevent Incoherence rule).

## Order

Stacks logically after #8 (Claude Code config); independent diffs so order doesn't strictly matter.

## Test plan

- [ ] All cross-references resolve: `AGENTS.md` ↔ `CONTRIBUTING.md` ↔ `README.md`
- [ ] `make help` matches commands listed in CONTRIBUTING.md
- [ ] No mention of files/dirs that don't exist (.claude/skills/, CLAUDE.md, etc.)
- [ ] Markdown lints clean: `make lint-md`

Generated with Claude <noreply@anthropic.com>