### PR TITLE
docs: fix broken landscape and changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package layout: `workers/` → `src/doc_pipeline_engine/`
 - Build system: setuptools → hatchling, pip → uv sync
 - Makefile: MARK sections, auto-help, lint-md, lint-links
-
-[Unreleased]: https://github.com/qte77/doc-pipeline-engine/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/qte77/doc-pipeline-engine/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ make test-contracts # schema round-trip tests
 
 - [Architecture](docs/architecture.md) — stage graph, runner vs stream, package layout
 - [Roadmap](docs/roadmap.md) — milestones with reasoning and implementation notes
-- [Scraping Landscape](docs/scraping-landscape.md) — web scraping and extraction tool survey
+- Landscape — pipeline tool surveys: [ingest](docs/landscape-ingest.md), [process](docs/landscape-process.md), [output](docs/landscape-output.md), [prior art](docs/landscape-prior-art.md)
+- [Scraping Landscape](https://github.com/qte77/polyfetch-scrape/blob/main/docs/scraping-landscape.md) — web scraping survey (moved to `polyfetch-scrape`)
 - [Changelog](CHANGELOG.md) — release history ([semver](https://semver.org/))


### PR DESCRIPTION
## Summary

- README.md: replace dead `docs/scraping-landscape.md` reference (file migrated to `polyfetch-scrape` in faedc92) with the new cross-repo link, and add the four landscape-* docs from PR #10.
- CHANGELOG.md: drop the `[Unreleased]` and `[0.1.0]` reference URLs — no v0.1.0 release/tag exists on GitHub yet, so they 404. Restore once the release is cut.

## Test plan

- [x] `make lint-md` passes
- [x] `make lint-links` passes (0 errors; was 3 before this PR)

Generated with Claude <noreply@anthropic.com>