### PR TITLE
docs: add CodeFactor badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![License](https://img.shields.io/badge/license-Apache_2.0-58f4c2.svg)](LICENSE)
 ![Version](https://img.shields.io/badge/version-0.1.0-58f4c2.svg)
 [![CodeQL](https://github.com/qte77/doc-pipeline-engine/actions/workflows/codeql.yaml/badge.svg)](https://github.com/qte77/doc-pipeline-engine/actions/workflows/codeql.yaml)
+[![CodeFactor](https://www.codefactor.io/repository/github/qte77/doc-pipeline-engine/badge)](https://www.codefactor.io/repository/github/qte77/doc-pipeline-engine)
 
 Modular document processing engine with contract-gated pipeline stages. Standalone module — usable independently or as a component in larger systems (e.g. polyforge, office-polyforge).
 


### PR DESCRIPTION
## Summary

Add the CodeFactor badge to the README header. CodeFactor is already a required CI check (CONTRIBUTING.md line 58) but had no badge alongside License / Version / CodeQL.

## Test plan

- [x] `make lint-md` passes
- [x] `make lint-links` passes (badge URL reachable)

Generated with Claude <noreply@anthropic.com>