### PR TITLE
chore: enable python-dev and commit-helper plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,9 @@
     "command": "bash .claude/scripts/statusline.sh"
   },
   "enabledPlugins": {
-    "context7@claude-plugins-official": true
+    "context7@claude-plugins-official": true,
+    "python-dev@qte77-claude-code-utils": true,
+    "commit-helper@qte77-claude-code-utils": true
   },
   "permissions": {
     "allow": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `.claude/settings.json` enables `python-dev` and `commit-helper` plugins from the `qte77-claude-code-utils` marketplace; `CONTRIBUTING.md` documents the plugin set under Setup
+
 ### Added
 
 - `docs/landscape-process.md` — process-stage survey (chunking, table/figure extraction, NER, RAG indexing, CanonicalDoc normalization)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,12 @@ make install        # uv sync — install dev dependencies
 Requires [uv](https://github.com/astral-sh/uv). Python version pinned in
 `pyproject.toml`.
 
+Claude Code plugins declared in `.claude/settings.json`
+(`python-dev`, `commit-helper` from `qte77-claude-code-utils`,
+`context7` from `claude-plugins-official`) provide the testing and
+commit-workflow conventions used in this repo. `rag-core` will be
+enabled when §0.5 indexing wiring begins.
+
 ## Quality commands
 
 | Command | Purpose |


### PR DESCRIPTION
## Summary

Declare project-level plugin enablement in \`.claude/settings.json\` so the repo is self-sufficient for downstream contributors whose user-level CC config may not include the qte77 marketplace plugins.

- \`python-dev@qte77-claude-code-utils\` — pytest + Hypothesis + inline-snapshot conventions, \`test_{module}_{component}_{behavior}\` naming, make-target alignment.
- \`commit-helper@qte77-claude-code-utils\` — conventional-commit + PR workflow.

\`rag-core\` is intentionally **not** enabled here. It lands when §0.5 indexing wiring begins; enabling it now would over-commit to a stage we haven't started.

\`tdd-core\`, \`docs-governance\`, \`cc-meta\`, \`code-review\` remain enabled at user level globally — no project-level entry needed.

## Test plan

- [x] \`make lint-md\` passes
- [x] \`make lint-links\` passes (0 errors)
- [x] settings.json validates (no schema breakage)

Generated with Claude <noreply@anthropic.com>