### PR TITLE
docs: add E2E prototype plan + hyperlink roadmap refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `docs/prototype-plan.md` — dual-variant E2E prototype plan (Claude Code vs landscape tools), Quick-tier-only, with TDD framing per `tdd-core` / `python-dev` plugins and a parallel-diff harness sketch. Roadmap §0.2.0, CONTRIBUTING doc hierarchy, and the four landscape files cross-link to it.
+
 ### Changed
 
 - `.claude/settings.json` enables `python-dev` and `commit-helper` plugins from the `qte77-claude-code-utils` marketplace; `CONTRIBUTING.md` documents the plugin set under Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,7 @@ Authoritative sources — update these, don't duplicate:
 - `docs/landscape-process.md` — process survey (chunking, NER, RAG indexing, normalization)
 - `docs/landscape-output.md` — output survey (rendering, office formats, templating, conformance)
 - `docs/landscape-prior-art.md` — E2E pipeline prior art and USP positioning
+- `docs/prototype-plan.md` — dual-variant E2E prototype plan (Claude Code vs landscape tools)
 - `AGENTS.md` — AI agent behavioral rules
 - `CONTRIBUTING.md` — this file
 

--- a/docs/landscape-ingest.md
+++ b/docs/landscape-ingest.md
@@ -8,7 +8,7 @@ Survey of candidates for the **ingest** stage — extraction backends, source co
 2. **Format coverage / source coverage** — what the tool actually reaches.
 3. **Runtime footprint** — Python-native preferred; JVM/heavy native deps must justify themselves.
 4. **Auth/credential model** — for source connectors, must support OAuth 2.0 / service-account flows.
-5. **Data-locality fit** — note cloud-only paths; relevant to §0.5 `local-only` / `claude-api-extracted-only` / `cloud-redacted` policies.
+5. **Data-locality fit** — note cloud-only paths; relevant to [§0.5.0](roadmap.md#050--domain-packs) `local-only` / `claude-api-extracted-only` / `cloud-redacted` policies.
 6. **Maintenance signal** — active releases, non-trivial user base.
 
 ## 1. Extraction backends
@@ -28,7 +28,7 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 
 ### Notes
 
-**docling vs Kreuzberg** — not redundant. docling is the layout-accurate path for PDFs that feed `CanonicalDoc`; Kreuzberg is the pragmatic catch-all for the formats docling doesn't handle well (email, xlsx, legacy Office). Run them side by side in 0.4.0 cross-validation.
+**docling vs Kreuzberg** — not redundant. docling is the layout-accurate path for PDFs that feed `CanonicalDoc`; Kreuzberg is the pragmatic catch-all for the formats docling doesn't handle well (email, xlsx, legacy Office). Run them side by side in [§0.4.0](roadmap.md#040--adapters) cross-validation.
 
 **Tesseract positioning** — don't expose as its own adapter. It's a dependency of the Python wrappers; surfacing it separately would duplicate configuration surface for no gain.
 
@@ -54,7 +54,7 @@ Wired behind a `SourceConnector` interface. Emit file lists / blob handles consu
 
 **msgraph-sdk vs O365** — prefer `msgraph-sdk` as primary; it is the officially maintained Microsoft library and maps 1:1 to Graph API docs. O365 stays as an optional shim.
 
-**Data-locality flagging** — every cloud-source connector must declare `data_locality: cloud` so the §0.5 policy layer can refuse to load it under a `local-only` profile. On-prem variants (EWS, Confluence Server, S3-compatible MinIO) are local-friendly.
+**Data-locality flagging** — every cloud-source connector must declare `data_locality: cloud` so the [§0.5.0](roadmap.md#050--domain-packs) policy layer can refuse to load it under a `local-only` profile. On-prem variants (EWS, Confluence Server, S3-compatible MinIO) are local-friendly.
 
 **boto3 endpoint override** — pass `endpoint_url` to reach MinIO, Backblaze B2, or other S3-compatible stores. No fork required.
 
@@ -84,15 +84,16 @@ Produce the file list that becomes `DiscoveryManifest` (`version`, `source`, `di
 ## See also
 
 - [ai-agents-research / CC-web-scraping-plugins-analysis.md](https://github.com/qte77/ai-agents-research/blob/main/docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md) — Claude Code plugins for web scraping, at the orchestration layer above the connectors and crawlers surveyed here.
+- [prototype-plan.md](prototype-plan.md) — how the candidates surveyed here get exercised in the v1 dual-variant prototype.
 
 ## Open questions
 
 - Should `DiscoveryManifest.source` be an enum (cloud-source ID) or a free string?
 - MS Graph throttling (429 / `Retry-After`) — does the connector layer own retry, or does polyfetch-scrape's fetch layer absorb it?
-- Adapter registry policy across extractors: first-match, ensemble, or declared per-domain? → revisit during 0.5.0 domain packs.
+- Adapter registry policy across extractors: first-match, ensemble, or declared per-domain? → revisit during [§0.5.0 — Domain packs](roadmap.md#050--domain-packs).
 - Minimum cross-validation set: which adapters must agree on which sample categories to call extraction "verified"?
-- Do we need handwriting OCR in scope for 0.4.0, or defer with GLM-OCR? → see AGENT_REQUESTS.md if raised.
-- watchdog watch-mode: in-scope for 0.5.0 streaming milestone, or defer to a separate `ingest-streaming` extra?
+- Do we need handwriting OCR in scope for [§0.4.0](roadmap.md#040--adapters), or defer with GLM-OCR? → see AGENT_REQUESTS.md if raised.
+- watchdog watch-mode: in-scope for the [§0.5.0](roadmap.md#050--domain-packs) streaming milestone, or defer to a separate `ingest-streaming` extra?
 
 ## References
 

--- a/docs/landscape-output.md
+++ b/docs/landscape-output.md
@@ -81,6 +81,7 @@ Backs the `FormatConformance` contract. Practical pattern: rely on writer librar
 ## See also
 
 - [ai-agents-research / CC-office-document-skills.md](https://github.com/qte77/ai-agents-research/blob/main/docs/cc-native/plugins-ecosystem/CC-office-document-skills.md) — how Claude Code itself handles office documents at the orchestration layer (Anthropic's `/v1/skills` API for docx/xlsx/pptx/pdf). Complementary view: this file covers the engine-layer Python libraries; the linked file covers the CC integration layer above them.
+- [prototype-plan.md](prototype-plan.md) — how the rendering and office-format candidates surveyed here get exercised in the v1 dual-variant prototype.
 
 ## Open questions
 

--- a/docs/landscape-prior-art.md
+++ b/docs/landscape-prior-art.md
@@ -16,13 +16,13 @@ This file informs USP positioning. It is *not* a buyer's guide.
 | Paper | What it covers | Relevance |
 |---|---|---|
 | **Agentic RAG: A Survey** ([arXiv:2501.09136](https://arxiv.org/abs/2501.09136)) | Taxonomy of agentic RAG architectures — agent cardinality, control structure, autonomy, knowledge representation. Names LlamaIndex Agentic Document Workflows as E2E reference. | Maps cleanly to our P1–P4 orchestration patterns; useful taxonomy reference. |
-| **RAG: Comprehensive Survey** ([arXiv:2506.00054](https://arxiv.org/abs/2506.00054)) | Adaptive / multi-source / query-refinement / hybrid retrieval families and their trade-offs. | Informs §0.5 RAG indexing choices in [landscape-process.md](landscape-process.md). |
+| **RAG: Comprehensive Survey** ([arXiv:2506.00054](https://arxiv.org/abs/2506.00054)) | Adaptive / multi-source / query-refinement / hybrid retrieval families and their trade-offs. | Informs [§0.5.0](roadmap.md#050--domain-packs) RAG indexing choices in [landscape-process.md](landscape-process.md). |
 | **Systematic Review of RAG Systems** ([arXiv:2507.18910](https://arxiv.org/abs/2507.18910)) | Multi-library systematic review (ACL, IEEE, ACM, Scholar) through mid-2025. | Coverage map for gaps (eval, governance). |
 | **Retrieval And Structuring (RAS)** ([arXiv:2509.10697](https://arxiv.org/abs/2509.10697)) | Argues unstructured-passage RAG is fundamentally limited; integrate structured knowledge (taxonomies, hierarchies, KGs). | Validates our `CanonicalDoc.root` tree (structured, not flat passages). |
 | **HetaRAG** ([arXiv:2509.21336](https://arxiv.org/abs/2509.21336)) | Hybrid retrieval across vector + KG + full-text + structured DBs; multimodal (text/diagrams/tables/math). | Reference architecture for cross-store retrieval if `CanonicalDoc` consumers fan out. |
 | **AccurateRAG** ([arXiv:2510.02243](https://arxiv.org/abs/2510.02243)) | Local-environment RAG QA framework; PDF-to-text, eval, fine-tuning. | Closest single-paper analog to our "data-locality first" stance. |
 | **Modular-RAG taxonomy** ([arXiv:2506.10408](https://arxiv.org/abs/2506.10408)) | Compartmentalises tasks into orchestrated modules (query reformulation, retrieval, ranking, synthesis). | Same modular philosophy as our stage-graph / contracts split. |
-| **Engineering the RAG Stack** ([arXiv:2601.05264](https://arxiv.org/html/2601.05264v1)) | Architecture + trust-framework review across retrieval / fusion / modality / trust / adaptivity. | Useful checklist for §0.6 eval. |
+| **Engineering the RAG Stack** ([arXiv:2601.05264](https://arxiv.org/html/2601.05264v1)) | Architecture + trust-framework review across retrieval / fusion / modality / trust / adaptivity. | Useful checklist for [§0.6.0](roadmap.md#060--eval) eval. |
 
 ## 2. OSS E2E systems
 
@@ -36,7 +36,7 @@ This file informs USP positioning. It is *not* a buyer's guide.
 | **AWS GenAI IDP Accelerator** ([repo](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws)) | Apache-2.0 | OCR → Bedrock classify → extract → assess → validate → summarize; SAML/OIDC SSO; private VPC; multi-model | **Vendor-locked competitor** — covers same E2E shape, but tied to AWS Bedrock + CloudFormation/CDK/Terraform. We are cloud-agnostic and embeddable. |
 | **AWS Sample IDP Pipeline (multimodal)** ([repo](https://github.com/aws-samples/sample-aws-idp-pipeline)) | Apache-2.0 | Multimodal (PDF/video/audio/image), hybrid search + KG, conversational UI | Reference architecture; explicitly not for production. |
 | **AWS aws-ai-intelligent-document-processing** ([repo](https://github.com/aws-samples/aws-ai-intelligent-document-processing)) | Apache-2.0 | Workshop materials + agentic IDP (Analyzer/Matcher/Extractor/Validator/Troubleshooter) | Reference patterns for agent role decomposition. |
-| **Document Processing for Regulated Industries** ([repo](https://github.com/aws-samples/document-processing-pipeline-for-regulated-industries)) | Apache-2.0 | Image/PDF processing with lineage and pipeline-ops metadata | Lineage pattern reference for §0.5 audit / `local-only` profile. |
+| **Document Processing for Regulated Industries** ([repo](https://github.com/aws-samples/document-processing-pipeline-for-regulated-industries)) | Apache-2.0 | Image/PDF processing with lineage and pipeline-ops metadata | Lineage pattern reference for [§0.5.0](roadmap.md#050--domain-packs) audit / `local-only` profile. |
 | **thetanishqrathore / IDP** ([repo](https://github.com/thetanishqrathore/IDP)) | Apache-2.0 | RAG-focused: hybrid search (vector + BM25 RRF), context-aware chunking, FastAPI + Qdrant | Solo-maintained; useful as a chunking-strategy reference. |
 | **Awesome Document Understanding** ([repo](https://github.com/tstanislawek/awesome-document-understanding)) | CC-BY (typical for awesome-lists) | Curated index of DU / IDP / RPA resources | Discovery aid for further candidates. |
 
@@ -65,8 +65,8 @@ What competitors *do not* offer that this project does:
 1. **Embeddable engine, not a service.** R2R, AWS IDP, Azure DI, Document AI are services. We ship as a Python library with a CLI; orchestrators (polyforge, office-polyforge, Claude Code plugins) embed us — there is no server to run.
 2. **Contracts as the public API.** Every stage validates against a JSON schema. The data plane is orchestration-agnostic — any system that can produce/consume the schemas can participate.
 3. **Strict license isolation.** Apache-2.0 default; AGPL (PyMuPDF) and JVM (Tika, veraPDF) only as opt-in extras. R2R, Unstructured, and the AWS samples are mostly Apache-2.0 too, but none of them publish a license-isolation policy as a first-class architectural commitment.
-4. **Data-locality policies as a contract dimension.** §0.5 will declare `local-only` / `claude-api-extracted-only` / `cloud-redacted` profiles that gate which adapters can load. None of the surveyed systems express this as a runtime policy — they assume cloud or assume local, without an enforced switch.
-5. **Domain packs.** §0.5 plans `mech-elec-cert` and `med-research-patents` packs (prompts, thresholds, formats). Reduces the configuration surface for regulated industries.
+4. **Data-locality policies as a contract dimension.** [§0.5.0](roadmap.md#050--domain-packs) will declare `local-only` / `claude-api-extracted-only` / `cloud-redacted` profiles that gate which adapters can load. None of the surveyed systems express this as a runtime policy — they assume cloud or assume local, without an enforced switch.
+5. **Domain packs.** [§0.5.0](roadmap.md#050--domain-packs) plans `mech-elec-cert` and `med-research-patents` packs (prompts, thresholds, formats). Reduces the configuration surface for regulated industries.
 6. **Two-surface split.** Heavy data plane (Python: extract, validate, render) is decoupled from the optional control plane (skills, agents, hooks). The control plane is replaceable; the data plane is not. Most competitors couple the two.
 7. **Output-format conformance contract.** `OutputFormat` + `FormatConformance` formalise what "valid output" means per tier. Most pipelines treat output as best-effort rendering; we treat it as a validated contract.
 
@@ -77,8 +77,12 @@ What competitors *do* better (areas to learn from):
 - LlamaIndex's Agentic Document Workflows — informs the P2/P4 orchestration patterns.
 - Unstructured's element-typing taxonomy — useful pre-art when refining the `CanonicalDoc.root` node taxonomy.
 
+## See also
+
+- [prototype-plan.md](prototype-plan.md) — the v1 dual-variant E2E prototype that operationalizes the gap analysis in this file (Claude Code vs landscape tools, side-by-side eval).
+
 ## Open questions
 
 - Should we publish a reference deployment (Docker compose) modelled on R2R, or hold the line as a pure library? Trade-off: easier evaluation vs. scope creep into ops.
-- Is the `awesome-document-understanding` list worth mining for §0.4 cross-validation samples?
-- Does the AccurateRAG paper's local-environment fine-tuning loop belong in §0.6 eval or as a separate domain-pack workflow?
+- Is the `awesome-document-understanding` list worth mining for [§0.4.0](roadmap.md#040--adapters) cross-validation samples?
+- Does the AccurateRAG paper's local-environment fine-tuning loop belong in [§0.6.0](roadmap.md#060--eval) eval or as a separate domain-pack workflow?

--- a/docs/landscape-process.md
+++ b/docs/landscape-process.md
@@ -1,6 +1,6 @@
 # Process Landscape
 
-Survey of candidates for the **process** stage — chunking, supplemental table/figure extraction, NER, RAG indexing, and normalization to `CanonicalDoc` (`ExtractionBundle → CanonicalDoc`, roadmap §0.5). Companion files: [landscape-ingest.md](landscape-ingest.md), [landscape-output.md](landscape-output.md), [landscape-prior-art.md](landscape-prior-art.md).
+Survey of candidates for the **process** stage — chunking, supplemental table/figure extraction, NER, RAG indexing, and normalization to `CanonicalDoc` (`ExtractionBundle → CanonicalDoc`, [roadmap [§0.5.0](roadmap.md#050--domain-packs).0](roadmap.md#050--domain-packs)). Companion files: [landscape-ingest.md](landscape-ingest.md), [landscape-output.md](landscape-output.md), [landscape-prior-art.md](landscape-prior-art.md).
 
 `CanonicalDoc` fields: `version`, `source_sha256`, `built_at`, `input_format`, `root` (normalized tree), `tier_summary` (Quick vs Comprehensive — see [architecture.md](architecture.md)). "Canonical" means a normalized tree rooted at `root` carrying tier-aware summary.
 
@@ -8,7 +8,7 @@ Survey of candidates for the **process** stage — chunking, supplemental table/
 
 1. **License compatibility** — Apache-2.0 / MIT preferred; AGPL/GPL opt-in only.
 2. **Runtime footprint** — Python-native preferred; model downloads and GPU requirements declared.
-3. **Data-locality fit** — local-only vs cloud-required; critical for §0.5 policy enforcement.
+3. **Data-locality fit** — local-only vs cloud-required; critical for [§0.5.0](roadmap.md#050--domain-packs) policy enforcement.
 4. **Format coverage / domain fit** — chunkers, NER models.
 5. **Maintenance signal** — active releases, non-trivial user base.
 
@@ -47,7 +47,7 @@ When extraction backends (docling, Kreuzberg) miss or mangle tables/figures.
 | **outlines** | Constrained LLM decoding for structured NER | Apache-2.0 | Python + torch + local LLM | local (with local model) | **Candidate (local-LLM)** — pairs with Ollama/vLLM; no cloud calls. |
 | **instructor** | Structured output via LLM function-calling | MIT | Python; OpenAI-compatible API | **cloud by default** | **Opt-in only** — violates `local-only` policy unless pointed at local vLLM. Gate behind `[ner-llm]` and require explicit endpoint config. |
 
-**Notes** — Data-locality is the critical axis. spaCy is the safe default. instructor/outlines are the precision ceiling; both require explicit opt-in. Cloud NER calls must be refused under §0.5 `local-only` profile.
+**Notes** — Data-locality is the critical axis. spaCy is the safe default. instructor/outlines are the precision ceiling; both require explicit opt-in. Cloud NER calls must be refused under [§0.5.0](roadmap.md#050--domain-packs) `local-only` profile.
 
 ## 4. RAG indexing
 
@@ -80,6 +80,10 @@ Three load-bearing claims a `CanonicalDoc` makes that downstream stages rely on:
 1. **Provenance is exact** — `source_sha256` is the cryptographic hash of the *bytes* that were extracted; `built_at` is the normalization timestamp. Together these identify which input + which extractor run produced this doc.
 2. **`root` is a tree** — heading hierarchy is preserved as nested structure, not as a flat element list. This is what enables tier-aware summarization (Quick = top headings + key claims; Comprehensive = full tree).
 3. **`tier_summary` is precomputed** — analysis stages do not re-derive it. This decouples downstream stages from the normalization choice and makes Quick output cheap.
+
+## See also
+
+- [prototype-plan.md](prototype-plan.md) — how the chunking, NER, and normalization candidates surveyed here get exercised in the v1 dual-variant prototype.
 
 ## Open questions
 

--- a/docs/prototype-plan.md
+++ b/docs/prototype-plan.md
@@ -1,0 +1,82 @@
+# E2E Prototype Plan
+
+First end-to-end walk-through of the [stage graph](architecture.md#stage-graph) on a single sample, run as **two parallel variants** so we can A/B Claude Code against the surveyed tools.
+
+Scope: **Quick tier only** (see [architecture.md → Output tiers](architecture.md#output-tiers)). Comprehensive tier is deferred to [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs); prototyping it now would over-commit before we know which V1 stages already do the job.
+
+## Goal
+
+Same input sample → both variants → identical output contract shape → mechanical diff. Answer the question: *which stages does Claude Code already handle well enough, and which actually need the engine-layer tools?*
+
+## Variant 1 — Claude Code + Anthropic API (Linux)
+
+| Stage | How |
+|---|---|
+| Discover | `pathlib.rglob()` over `samples/` → `DiscoveryManifest` |
+| Extract — PDF | `claude_cli_adapter` posts file via Messages API `documents` block; Claude returns JSON matching `ExtractionBundle` |
+| Extract — DOCX/XLSX/PPTX | Preprocess with `python-docx` / `openpyxl` / `python-pptx` (flatten content), then Claude turn → `ExtractionBundle` |
+| Normalize | Claude turn: `ExtractionBundle → CanonicalDoc` (heading tree + `tier_summary`) |
+| Analyze | Claude turn over `CanonicalDoc.root` → `AnalysisReport` (top headings, key claims, top-N entities) |
+| Render | Claude writes Quick-tier 1-page Markdown summary from `AnalysisReport` |
+| Eval | Claude self-eval (schema check + 1 faithfulness probe) → `EvalReport` |
+
+Anthropic's office-document skills (`anthropics/skills`) are Claude.ai-only — not invokable from Claude Code on Linux. Office formats need preprocessing libs.
+
+## Variant 2 — Tools from the landscape
+
+| Stage | How |
+|---|---|
+| Discover | `pathlib.rglob()` → `DiscoveryManifest` (shared with V1) |
+| Extract | **docling** (PDF/Office), **Kreuzberg** (long tail) → `ExtractionBundle`. See [landscape-ingest.md](landscape-ingest.md). |
+| Normalize | Thin Python adapter `DoclingDocument → CanonicalDoc` (adds `source_sha256`, `built_at`, runs tier-split). See [landscape-process.md → Normalization to CanonicalDoc](landscape-process.md#5-normalization-to-canonicaldoc). |
+| Analyze | **spaCy** NER over `root` text nodes → `AnalysisReport` (heading walk for key claims; no RAG at Quick tier). See [landscape-process.md → Entity extraction / NER](landscape-process.md#3-entity-extraction--ner). |
+| Render | **Jinja2** template → 1-page Markdown. See [landscape-output.md](landscape-output.md). |
+| Eval | Schema gates + **DeepEval** or **RAGAs** for faithfulness → `EvalReport`. See [roadmap §0.6.0 — Eval](roadmap.md#060--eval). |
+
+## Eval axes
+
+Both variants emit valid contracts at every gate (see [architecture.md → Core idea](architecture.md#core-idea)). A small harness (~100 LOC) runs both legs on the same sample and diffs:
+
+1. **Faithfulness** — does the summary contradict the source? (RAGAs faithfulness metric + manual spot-check)
+2. **Determinism** — re-run 3× per leg; assert byte equality (V2) or N-of-M consistency (V1)
+3. **Latency** — wall-clock per stage
+4. **Cost** — Claude API tokens (V1) vs compute seconds (V2)
+5. **Layout fidelity** — table/figure preservation (becomes critical for Comprehensive tier)
+
+## TDD framing
+
+Per `tdd-core/testing-tdd` and `python-dev/testing-python` plugins (declared in [`.claude/settings.json`](../.claude/settings.json)):
+
+- **pytest** for known cases — Arrange-Act-Assert; naming `test_{module}_{component}_{behavior}`
+- **Hypothesis** for property-based assertions on V1's nondeterministic stages — "extracted entities ⊇ {known minimum}", "schema validates", "key claims contain expected substrings"
+- **inline-snapshot** for golden-output regression on V2's deterministic stages
+- Schema gates already TDD'd in [roadmap §0.1.0 — Contracts](roadmap.md#010--contracts) (38 round-trip tests)
+
+| Stage type | Tooling |
+|---|---|
+| Pure functions (V2 discover, normalize, render) | pytest + inline-snapshot |
+| LLM stages (V1 extract, normalize, analyze, render) | pytest + Hypothesis property assertions |
+| Parallel diff harness | pytest with mock pipelines |
+
+## Sequencing
+
+1. **V1 first** — fastest path to any working E2E loop. ~1–2 days. Builds on [roadmap §0.2.0 — Runner](roadmap.md#020--runner).
+2. **V2 normalize + render only**, reusing V1 extraction output. Lets us A/B "Claude extract vs docling extract" cheaply by swapping one stage.
+3. **Full V2** + parallel diff harness. Run the eval matrix.
+4. Decide per stage: keep Claude, swap to tools, or run both as cross-validation (mirrors [roadmap §0.4.0 — Adapters](roadmap.md#040--adapters) cross-validation strategy).
+
+PDF is the cleanest A/B — neither variant shares Office-format deps in extract. Office formats share `python-docx` / `openpyxl` / `python-pptx`, so the V1-vs-V2 signal there is weaker.
+
+## Out of scope for v1
+
+- Comprehensive tier (full canonical tree, RAG indexing, citations) — [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs)
+- Source connectors beyond local filesystem — [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs)
+- Domain packs — [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs)
+- `OutputFormat` / `FormatConformance` strict validators — [roadmap §0.6.0 — Eval](roadmap.md#060--eval)
+- Multi-sample evaluation — once v1 lands on one sample, expand sample set
+
+## References
+
+- [Architecture](architecture.md) — stage graph + contracts
+- [Roadmap](roadmap.md) — milestone scope per version
+- [landscape-ingest.md](landscape-ingest.md), [landscape-process.md](landscape-process.md), [landscape-output.md](landscape-output.md), [landscape-prior-art.md](landscape-prior-art.md) — tool surveys feeding this plan

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ Schemas define the interface between every pipeline stage. Nothing runs without 
 
 ## 0.2.0 — Runner
 
-Stage chain that passes JSON between stages in-process. Minimum viable pipeline.
+Stage chain that passes JSON between stages in-process. Minimum viable pipeline. Prototype walk-through: see [prototype-plan.md](prototype-plan.md).
 
 **Why now**: contracts without a runner are just static files. The runner proves the contracts work as a real data flow.
 


### PR DESCRIPTION
## Summary

Two topical commits:

1. **\`docs(prototype): add prototype-plan.md and cross-links\`** — new \`docs/prototype-plan.md\` captures the v1 dual-variant E2E walk-through (Variant 1 = Claude Code + Anthropic API on Linux; Variant 2 = landscape tools). Quick-tier only; Comprehensive deferred to §0.5.0. TDD framing per \`tdd-core\` / \`python-dev\` plugins (pytest + Hypothesis for V1, inline-snapshot for V2). Cross-links from roadmap §0.2.0, CONTRIBUTING doc hierarchy, CHANGELOG \`[Unreleased]\`.

2. **\`docs: hyperlink roadmap §-refs and add prototype-plan See-also\`** — convert plain-text \`§0.4\` / \`§0.5\` / \`§0.6\` mentions in the four landscape files to anchored links into \`roadmap.md\`. Each landscape file gains a \`See-also\` pointer to \`prototype-plan.md\`. Link-only edits, no content changes.

## Out of scope (intentional)

- \`rag-core\` plugin enablement and Comprehensive-tier RAG indexing — defer until §0.5.0 wiring begins (per YAGNI).
- \`landscape-process.md\` chunking/vector-store choice (LangChain+Chroma vs rag-core's heading-boundary+FAISS) — resolves at §0.5.0 implementation, not here.

## Test plan

- [x] \`make lint-md\` passes
- [x] \`make lint-links\` passes (152 links checked, 0 errors)
- [x] All new anchors (\`#020--runner\`, \`#040--adapters\`, \`#050--domain-packs\`, \`#060--eval\`, \`#stage-graph\`, \`#output-tiers\`, \`#core-idea\`) resolve

Generated with Claude <noreply@anthropic.com>