### PR TITLE
chore: fix MD060 and adopt lychee.toml config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ enabled when §0.5 indexing wiring begins.
 ## Quality commands
 
 | Command | Purpose |
-|---|---|
+| --- | --- |
 | `make test` | Full pytest suite |
 | `make test-contracts` | JSON schema round-trip tests only |
 | `make lint` | Ruff check on Python sources |

--- a/Makefile
+++ b/Makefile
@@ -34,15 +34,15 @@ lint:  ## Lint Python with ruff
 lint-md:  ## Lint Markdown (markdownlint, disable MD013)
 	echo "--- lint-md"
 	if command -v markdownlint > /dev/null 2>&1; then
-		markdownlint '**/*.md' --ignore '.venv/**' --ignore 'samples/**' --ignore 'docs/plans/**' --disable MD013 MD060
+		markdownlint '**/*.md' --ignore '.venv/**' --ignore 'samples/**' --ignore 'docs/plans/**' --disable MD013
 	else
 		echo "markdownlint not installed — run: npm install -g markdownlint-cli"
 	fi
 
-lint-links:  ## Check links in Markdown (lychee)
+lint-links:  ## Check links in Markdown (lychee, see lychee.toml)
 	echo "--- lint-links"
 	if command -v lychee > /dev/null 2>&1; then
-		lychee --exclude-path .venv --exclude-path samples .
+		lychee .
 	else
 		echo "lychee not installed — see https://github.com/lycheeverse/lychee"
 	fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ No hard dependencies on any orchestrator or consumer. Contracts are the public A
 ## Output tiers
 
 | Tier | Extraction | Template | Eval |
-|------|-----------|----------|------|
+| ------ | ----------- | ---------- | ------ |
 | **Quick** | Headings + key claims + top-5 entities | 1-page Markdown summary | Smoke (schema + 1 faithfulness) |
 | **Comprehensive** | Full canonical tree + RAG index + tables/figures/citations | IMRaD / tech-spec | RAGAs + TruLens + human-in-loop |
 

--- a/docs/landscape-ingest.md
+++ b/docs/landscape-ingest.md
@@ -16,7 +16,7 @@ Survey of candidates for the **ingest** stage — extraction backends, source co
 Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 
 | Tool | Primary role | License | Runtime | Formats | Verdict |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | **docling** | Layout-aware PDF/Office → structured doc | MIT | Python + torch | PDF, DOCX, PPTX, HTML, images | **Primary** — best layout fidelity, native target for `CanonicalDoc`. |
 | **Kreuzberg** | Async multi-format extraction facade | MIT | Python (pypdfium2, Tesseract, python-docx, …) | PDF, Office, images, email, HTML | **Primary (breadth)** — covers the long tail with one adapter. |
 | **claude_cli_adapter** | LLM-based extraction via Claude Code CLI | n/a (our code) | Claude CLI | Any (LLM-mediated) | **Primary (reference)** — end-to-end wired first; cross-validation baseline. |
@@ -41,7 +41,7 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 Wired behind a `SourceConnector` interface. Emit file lists / blob handles consumed by extraction.
 
 | Tool | Source system | License | Runtime | Auth | Locality | Verdict |
-|---|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- | --- |
 | **msgraph-sdk** | SharePoint / OneDrive (MS Graph) | MIT | Python-native | OAuth 2.0 (MSAL / client-credentials) | cloud | **Primary** — official Microsoft SDK; covers SharePoint and OneDrive via single Graph surface. |
 | **O365** | SharePoint / OneDrive (MS Graph) | Apache-2.0 | Python-native | OAuth 2.0 / device flow | cloud | **Optional** — friendlier surface than msgraph-sdk; less actively maintained. |
 | **atlassian-python-api** | Confluence (REST v1/v2) | Apache-2.0 | Python-native | API token / OAuth 2.0 | cloud or on-prem | **Primary** — canonical community SDK; covers Cloud and Server; exposes page-tree traversal. |
@@ -65,7 +65,7 @@ Wired behind a `SourceConnector` interface. Emit file lists / blob handles consu
 Produce the file list that becomes `DiscoveryManifest` (`version`, `source`, `discovered_at`, `files`).
 
 | Tool | Role | License | Runtime | `DiscoveryManifest` fit | Verdict |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | **polyfetch-scrape** (sibling repo) | Web crawl → URL/file list | Apache-2.0 (internal) | Python-native | Native — already emits structured manifests | **Primary (web)** — purpose-built sibling; reuse output as `DiscoveryManifest` directly. |
 | **trafilatura** | Web content extraction + URL crawl | Apache-2.0 | Python-native | Adapt URL list to `files[]` | **Optional (targeted web)** — lightweight; excellent boilerplate stripping; for single-site crawls where Scrapy overhead is unjustified. |
 | **httpx** | HTTP client for bespoke crawlers | BSD-3-Clause | Python-native | Raw — caller builds manifest | **Building block** — async-native, HTTP/2; recommended base for custom connector fetch loops. |

--- a/docs/landscape-output.md
+++ b/docs/landscape-output.md
@@ -18,7 +18,7 @@ Output emits documents validating against `OutputFormat` (`id`, `version`, `tier
 ## 1. Rendering engines
 
 | Tool | License | Runtime | Output formats | Verdict |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | **WeasyPrint** | BSD-3-Clause | Python-native | PDF, PNG (from HTML/CSS) | **Primary (PDF)** — pure-Python HTML→PDF; good CSS3 support; no Haskell/Rust install. |
 | **ReportLab** | BSD-3-Clause / commercial (RLPDF) | Python-native | PDF | **Primary (programmatic PDF)** — battle-tested; preferred for data-heavy tables and charts in Comprehensive. |
 | **Typst** | Apache-2.0 | External binary (Rust); `typst` Python binding | PDF, PNG, SVG | **Optional** — modern TeX replacement; Python binding removes shell-out. |
@@ -32,7 +32,7 @@ Output emits documents validating against `OutputFormat` (`id`, `version`, `tier
 ## 2. Office formats (write side)
 
 | Tool | License | Runtime | Formats | Verdict |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | **python-docx** | MIT | Python-native | DOCX | **Primary** — standard DOCX writer; first-class `CanonicalDoc → DOCX` adapter target. |
 | **docxtpl** | LGPL-2.1 | Python-native (wraps python-docx) | DOCX | **Primary (templates)** — Jinja2-in-DOCX; LGPL is library-use safe for Apache-2.0 callers when not modifying the lib. Confirm with legal before redistributing modified copies. |
 | **python-pptx** | MIT | Python-native | PPTX | **Primary** — only serious Python PPTX writer. |
@@ -43,7 +43,7 @@ Output emits documents validating against `OutputFormat` (`id`, `version`, `tier
 ## 3. Templating engines
 
 | Tool | License | Runtime | Use case | Verdict |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | **Jinja2** | BSD-3-Clause | Python-native | HTML, MD, LaTeX, Typst text templates | **Primary** — de-facto standard; covers Quick and Comprehensive text templates. |
 | **pystache** | MIT | Python-native | Mustache logic-less templates | **Optional** — pick where logic-less is required for cross-language template sharing. |
 | **chevron** | MIT | Python-native | Mustache | **Avoid** — unmaintained since 2021; prefer pystache. |
@@ -56,7 +56,7 @@ Output emits documents validating against `OutputFormat` (`id`, `version`, `tier
 Backs the `FormatConformance` contract. Practical pattern: rely on writer libraries for structural correctness in the hot path, delegate strict format validators (PDF/A, HTML5) to CI or opt-in extras.
 
 | Tool | License | Runtime | Validates | Role |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | **python-docx structural check** | MIT | Python-native | DOCX (OOXML constructor raises on malformed) | **Runtime** — pair with `lxml` schema validation for deeper checks. |
 | **WeasyPrint runtime errors** | BSD-3-Clause | Python-native | HTML/CSS for PDF rendering | **Runtime** — raises on unrenderable input. |
 | **pymarkdownlnt** | MIT | Python-native | CommonMark / GFM Markdown | **Runtime** — backs Quick-tier Markdown conformance. |
@@ -71,7 +71,7 @@ Backs the `FormatConformance` contract. Practical pattern: rely on writer librar
 ## Recommended defaults vs. opt-in extras
 
 | Tier | Default (no extra) | Opt-in extra |
-|---|---|---|
+| --- | --- | --- |
 | PDF | WeasyPrint, ReportLab | Pandoc (`[pandoc]`), Typst (`[typst]`), Quarto (`[quarto]`) |
 | DOCX | python-docx, docxtpl | — |
 | XLSX/PPTX | openpyxl, python-pptx | xlsxwriter, odfpy |

--- a/docs/landscape-prior-art.md
+++ b/docs/landscape-prior-art.md
@@ -14,7 +14,7 @@ This file informs USP positioning. It is *not* a buyer's guide.
 ## 1. Academic prior art (arXiv, 2025)
 
 | Paper | What it covers | Relevance |
-|---|---|---|
+| --- | --- | --- |
 | **Agentic RAG: A Survey** ([arXiv:2501.09136](https://arxiv.org/abs/2501.09136)) | Taxonomy of agentic RAG architectures — agent cardinality, control structure, autonomy, knowledge representation. Names LlamaIndex Agentic Document Workflows as E2E reference. | Maps cleanly to our P1–P4 orchestration patterns; useful taxonomy reference. |
 | **RAG: Comprehensive Survey** ([arXiv:2506.00054](https://arxiv.org/abs/2506.00054)) | Adaptive / multi-source / query-refinement / hybrid retrieval families and their trade-offs. | Informs [§0.5.0](roadmap.md#050--domain-packs) RAG indexing choices in [landscape-process.md](landscape-process.md). |
 | **Systematic Review of RAG Systems** ([arXiv:2507.18910](https://arxiv.org/abs/2507.18910)) | Multi-library systematic review (ACL, IEEE, ACM, Scholar) through mid-2025. | Coverage map for gaps (eval, governance). |
@@ -27,7 +27,7 @@ This file informs USP positioning. It is *not* a buyer's guide.
 ## 2. OSS E2E systems
 
 | System | License | E2E scope | Position |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **SciPhi-AI / R2R** ([repo](https://github.com/SciPhi-AI/R2R)) | Apache-2.0 | Ingest (PDF/DOCX/MD/MP3/PNG…), chunk, embed, KG extraction, hybrid search, agentic RAG, REST API | **Closest competitor** by feature surface. Difference: R2R is a deployed *service* (REST + Postgres + Docker compose); we are an *embeddable engine* with JSON contracts. |
 | **Unstructured.io** ([repo](https://github.com/Unstructured-IO/unstructured)) | Apache-2.0 (OSS core) + commercial API | Ingest + element-typed extraction + chunking; downstream RAG via partner libs | **Adjacent** — already a candidate processor (see [landscape-process.md](landscape-process.md)). Scope is ingest+extract; we cover all five stages with strict contracts. |
 | **LlamaIndex + LlamaParse + Agentic Document Workflows** ([LlamaIndex](https://github.com/run-llama/llama_index)) | MIT (LlamaIndex), commercial (LlamaParse) | Parse → index → agentic workflow over docs | **Inspiration, not competitor** — we *use* LlamaIndex as a candidate framework; ADW is one possible orchestration pattern over our stages. |

--- a/docs/landscape-process.md
+++ b/docs/landscape-process.md
@@ -15,7 +15,7 @@ Survey of candidates for the **process** stage — chunking, supplemental table/
 ## 1. Chunking strategies
 
 | Tool | Strategy | License | Runtime | Locality | Verdict |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | **langchain-text-splitters** | Fixed-size, recursive, Markdown/HTML-aware | MIT | Python, CPU | local | **Primary** — zero-model splits; `MarkdownHeaderTextSplitter` maps onto `CanonicalDoc.root` heading tree. Slim sub-package avoids full LangChain footprint. |
 | **llama-index-core** node parsers | Semantic, layout-aware, sentence-window, hierarchical | MIT | Python; some pull sentence-transformers (GPU optional) | local | **Candidate** — `HierarchicalNodeParser` mirrors tier hierarchy; evaluate footprint. |
 | **semantic-chunker** | Embedding-similarity boundary detection | MIT | Python + sentence-transformers (~300 MB) | local | **Optional (Comprehensive)** — improves coherence; gate behind `[semantic]` extra. |
@@ -29,7 +29,7 @@ Survey of candidates for the **process** stage — chunking, supplemental table/
 When extraction backends (docling, Kreuzberg) miss or mangle tables/figures.
 
 | Tool | Role | License | Runtime | Locality | Verdict |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | **pdfplumber** | Text + tables + bbox from PDFs | MIT | Python + pdfminer.six | local | **Primary (light fallback)** — no native deps beyond pdfminer; lower recall than Camelot but easy default. |
 | **Camelot** | Lattice + stream table extraction from PDFs | MIT | Python + Ghostscript + OpenCV | local | **Optional** — best lattice recall on born-digital PDFs; Ghostscript native dep. |
 | **img2table** | Heuristic table extraction from images and PDFs | Apache-2.0 | Python + OpenCV | local | **Optional** — CPU-only fallback for image/scan paths without GPU. |
@@ -40,7 +40,7 @@ When extraction backends (docling, Kreuzberg) miss or mangle tables/figures.
 ## 3. Entity extraction / NER
 
 | Tool | Approach | License | Runtime | Locality | Verdict |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | **spaCy** | Rule + statistical NER, 50+ language models | MIT | Python; models 12–560 MB | local | **Primary** — deterministic, fast, no GPU for `en_core_web_sm/md`. |
 | **GLiNER** | Generative LM-based zero-shot NER | Apache-2.0 | Python + torch (~500 MB) | local | **Candidate (Comprehensive)** — domain-specific entities without retraining; gate behind `[ner-gliner]`. |
 | **Flair** | Contextual string embeddings NER | MIT | Python + torch (300 MB–1 GB) | local | **Optional** — strong on CoNLL; redundant if GLiNER adopted. |
@@ -54,7 +54,7 @@ When extraction backends (docling, Kreuzberg) miss or mangle tables/figures.
 Framework vs vector store are orthogonal. Recommended default: LlamaIndex (framework) + Chroma (store) — both Apache-2.0/MIT, embedded, no server.
 
 | Tool | Role | License | Runtime | Locality | Verdict |
-|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- |
 | **llama-index-core** | RAG framework + ingestion pipeline | MIT | Python | local (LLM calls configurable) | **Primary (framework)** — `VectorStoreIndex` wraps any store. |
 | **Haystack (haystack-ai)** | RAG pipeline orchestration | Apache-2.0 | Python | local | **Alternative** — deeper graph; prefer LlamaIndex unless consumer already uses Haystack. |
 | **Chroma (chromadb)** | Embedded vector store | Apache-2.0 | Python; optional native HNSW | local | **Primary (store)** — zero-server, embedded, no Docker. |
@@ -65,7 +65,7 @@ Framework vs vector store are orthogonal. Recommended default: LlamaIndex (frame
 ## 5. Normalization to CanonicalDoc
 
 | Source / tool | What it provides | Gap vs `CanonicalDoc` | License | Verdict |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | **docling `DoclingDocument`** | Hierarchical doc tree with headings, tables, figures, text blocks; JSON-serializable | Missing `source_sha256`, `built_at`, `tier_summary`; table/figure refs need mapping to `root` leaves | MIT | **Primary normalization source** — richest structural fidelity; thin adapter adds provenance + tier split. |
 | **unstructured element schema** | Flat list of typed elements (Title, NarrativeText, Table, Image, …) | No hierarchy; reconstruct from sequence; no provenance | Apache-2.0 | **Secondary** — reconstruct `root` via heading-indent heuristic. Lossier than docling. |
 | **Pandoc AST** (via `pypandoc`) | Universal AST; 40+ formats | Pandoc binary GPL; AST is Haskell-native JSON; no provenance | GPL-2+ (Pandoc); MIT (`pypandoc`) | **Optional** — for Office/Markdown/RST sources docling handles poorly. Pandoc binary called as subprocess (does not link), but document the GPL gate. |

--- a/docs/prototype-plan.md
+++ b/docs/prototype-plan.md
@@ -11,7 +11,7 @@ Same input sample → both variants → identical output contract shape → mech
 ## Variant 1 — Claude Code + Anthropic API (Linux)
 
 | Stage | How |
-|---|---|
+| --- | --- |
 | Discover | `pathlib.rglob()` over `samples/` → `DiscoveryManifest` |
 | Extract — PDF | `claude_cli_adapter` posts file via Messages API `documents` block; Claude returns JSON matching `ExtractionBundle` |
 | Extract — DOCX/XLSX/PPTX | Preprocess with `python-docx` / `openpyxl` / `python-pptx` (flatten content), then Claude turn → `ExtractionBundle` |
@@ -25,7 +25,7 @@ Anthropic's office-document skills (`anthropics/skills`) are Claude.ai-only — 
 ## Variant 2 — Tools from the landscape
 
 | Stage | How |
-|---|---|
+| --- | --- |
 | Discover | `pathlib.rglob()` → `DiscoveryManifest` (shared with V1) |
 | Extract | **docling** (PDF/Office), **Kreuzberg** (long tail) → `ExtractionBundle`. See [landscape-ingest.md](landscape-ingest.md). |
 | Normalize | Thin Python adapter `DoclingDocument → CanonicalDoc` (adds `source_sha256`, `built_at`, runs tier-split). See [landscape-process.md → Normalization to CanonicalDoc](landscape-process.md#5-normalization-to-canonicaldoc). |
@@ -53,7 +53,7 @@ Per `tdd-core/testing-tdd` and `python-dev/testing-python` plugins (declared in 
 - Schema gates already TDD'd in [roadmap §0.1.0 — Contracts](roadmap.md#010--contracts) (38 round-trip tests)
 
 | Stage type | Tooling |
-|---|---|
+| --- | --- |
 | Pure functions (V2 discover, normalize, render) | pytest + inline-snapshot |
 | LLM stages (V1 extract, normalize, analyze, render) | pytest + Hypothesis property assertions |
 | Parallel diff harness | pytest with mock pipelines |

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,26 @@
+# Lychee link checker configuration
+# https://lychee.cli.rs/usage/config/
+
+# Accept status codes commonly returned by bot-blocking sites
+# 403 = Forbidden (procycons.com, dl.acm.org, iso.org, etc.)
+# 401 = Unauthorized (huggingface.co/spaces, semanticscholar.org)
+# 429 = Too Many Requests (rate limiting)
+# 406 = Not Acceptable (arxiv.org — bot-blocking)
+accept = [200, 202, 204, 301, 401, 403, 406, 429]
+
+# Exclude paths from scanning
+exclude_path = [
+  ".venv",
+  "samples",
+]
+
+# Exclude URLs that are expected to fail in CI
+exclude = [
+  # --- Non-routable / local ---
+  "^https?://localhost",
+
+  # --- Not yet released ---
+  # v0.1.0 release tag URLs in CHANGELOG once tag is cut
+  "^https://github\\.com/qte77/doc-pipeline-engine/releases/tag/v",
+  "^https://github\\.com/qte77/doc-pipeline-engine/compare/v",
+]


### PR DESCRIPTION
## Summary

Two topical commits.

1. **\`docs: fix MD060 table separator style across all markdown\`** — pad table separator rows with spaces so they pass markdownlint MD060/table-column-style:
   - \`|---|---|\` → \`| --- | --- |\`
   - Pure mechanical fix; no content changes.
   - 7 files touched (CONTRIBUTING.md, docs/architecture.md, four landscape-* docs, prototype-plan.md).

2. **\`chore: enable MD060 in lint-md and add lychee.toml\`** — \`make lint-md\` no longer disables MD060 (MD013 remains disabled). New \`lychee.toml\` (adapted from Agents-eval) accepts bot-blocked status codes (401/403/406/429) so future link checks don't trip on pages like procycons.com or arxiv.org, and excludes the v0.1.0 release-tag URLs that 404 until the release is cut. Makefile \`lint-links\` simplified to read config from \`lychee.toml\`.

## Test plan

- [x] \`make lint-md\` passes (MD060 + MD024 enabled, MD013 disabled)
- [x] \`make lint-links\` passes (152 links, 0 errors, 4 informational redirects)

Generated with Claude <noreply@anthropic.com>