### PR TITLE
feat(runner): add stage-chain runner with gate validation (§0.2.0)

### DIFF
--- a/src/doc_pipeline_engine/base/adapter.py
+++ b/src/doc_pipeline_engine/base/adapter.py
@@ -1,0 +1,26 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Adapter ABC for extraction backends.
+
+An adapter consumes a single file entry from a `DiscoveryManifest` and emits
+an `ExtractionBundle`. Concrete adapters live in `stages/` (e.g. Kreuzberg).
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class AdapterBase(ABC):
+    name: str
+    version: str
+
+    @abstractmethod
+    def extract(self, manifest_file: dict[str, Any]) -> dict[str, Any]:
+        """Convert one DiscoveryManifest file entry to an ExtractionBundle dict."""
+        ...

--- a/src/doc_pipeline_engine/runner.py
+++ b/src/doc_pipeline_engine/runner.py
@@ -1,0 +1,53 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Stage chain runner with gate validation.
+
+A stage is a 3-tuple ``(name, callable, output_contract_name)``. The runner
+threads the output of each stage into the next, validating the output
+against its declared contract via `base.contracts.validate`. The chain
+halts on the first validation failure with a `PipelineError` carrying the
+offending stage name and contract.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import jsonschema
+
+from doc_pipeline_engine.base.contracts import validate
+
+StageCallable = Callable[[dict[str, Any]], dict[str, Any]]
+Stage = tuple[str, StageCallable, str]
+
+
+class PipelineError(Exception):
+    """Raised when a stage output fails its contract gate."""
+
+    def __init__(self, stage_name: str, contract_name: str, detail: str) -> None:
+        self.stage_name = stage_name
+        self.contract_name = contract_name
+        self.detail = detail
+        super().__init__(
+            f"stage={stage_name!r} contract={contract_name!r}: {detail}"
+        )
+
+
+def run(stages: list[Stage], seed: dict[str, Any]) -> list[dict[str, Any]]:
+    """Execute stages in order, validating each output against its contract."""
+    outputs: list[dict[str, Any]] = []
+    current: dict[str, Any] = seed
+    for stage_name, fn, contract_name in stages:
+        result = fn(current)
+        try:
+            validate(contract_name, result)
+        except jsonschema.ValidationError as e:
+            raise PipelineError(stage_name, contract_name, e.message) from e
+        outputs.append(result)
+        current = result
+    return outputs

--- a/src/doc_pipeline_engine/stages/__init__.py
+++ b/src/doc_pipeline_engine/stages/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Pipeline stages. Concrete stage modules added per phase (discover,
+extract, v1_*, v2_*).
+"""

--- a/tests/test_runner_chain_halts_on_gate_failure.py
+++ b/tests/test_runner_chain_halts_on_gate_failure.py
@@ -1,0 +1,91 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Runner chain behavior: passes valid outputs through, halts on first
+gate failure, and surfaces stage and contract names in the error.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from doc_pipeline_engine.runner import PipelineError, run
+
+SHA_ZERO = "0" * 64
+NOW = datetime.now(timezone.utc).isoformat()
+
+
+def _valid_discovery_manifest(_seed: dict) -> dict:
+    return {
+        "version": "0.1.0",
+        "source": {"root": "/data/ingest", "kind": "folder"},
+        "discovered_at": NOW,
+        "files": [
+            {
+                "path": "a.pdf",
+                "size_bytes": 100,
+                "sha256": SHA_ZERO,
+                "file_type": "pdf",
+            }
+        ],
+    }
+
+
+def _valid_extraction_bundle(_manifest: dict) -> dict:
+    return {
+        "version": "0.1.0",
+        "source_path": "a.pdf",
+        "source_sha256": SHA_ZERO,
+        "adapter": {"name": "stub", "version": "0.0.0"},
+        "extracted_at": NOW,
+        "content": {"text": "hi", "layout": []},
+    }
+
+
+def _invalid_extraction_bundle(_manifest: dict) -> dict:
+    bundle = _valid_extraction_bundle(_manifest)
+    del bundle["content"]
+    return bundle
+
+
+def test_runner_chain_passes_valid_outputs_through_all_stages() -> None:
+    stages = [
+        ("discover", _valid_discovery_manifest, "DiscoveryManifest"),
+        ("extract", _valid_extraction_bundle, "ExtractionBundle"),
+    ]
+
+    outputs = run(stages, seed={})
+
+    assert len(outputs) == 2
+    assert outputs[0]["files"][0]["path"] == "a.pdf"
+    assert outputs[1]["adapter"]["name"] == "stub"
+
+
+def test_runner_chain_halts_on_first_invalid_output() -> None:
+    stages = [
+        ("discover", _valid_discovery_manifest, "DiscoveryManifest"),
+        ("extract", _invalid_extraction_bundle, "ExtractionBundle"),
+    ]
+
+    with pytest.raises(PipelineError):
+        run(stages, seed={})
+
+
+def test_runner_pipeline_error_contains_stage_and_contract_names() -> None:
+    stages = [
+        ("discover", _valid_discovery_manifest, "DiscoveryManifest"),
+        ("extract", _invalid_extraction_bundle, "ExtractionBundle"),
+    ]
+
+    with pytest.raises(PipelineError) as exc:
+        run(stages, seed={})
+
+    assert exc.value.stage_name == "extract"
+    assert exc.value.contract_name == "ExtractionBundle"
+    assert "extract" in str(exc.value)
+    assert "ExtractionBundle" in str(exc.value)


### PR DESCRIPTION
## Summary

First piece of §0.2.0 — Runner. A stage chain that threads each stage's output dict into the next, gate-validating against the declared contract. Halts on first failure with an actionable error.

Per the approved [prototype plan](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/prototype-plan.md), this is **PR 1 of 6** and unblocks all downstream phases.

### Public API

\`\`\`python
# base.adapter
class AdapterBase(ABC):
    name: str
    version: str
    @abstractmethod
    def extract(self, manifest_file: dict) -> dict: ...

# runner
Stage = tuple[str, StageCallable, str]   # (stage_name, fn, output_contract_name)

class PipelineError(Exception): ...

def run(stages: list[Stage], seed: dict) -> list[dict]: ...
\`\`\`

## TDD

Per \`tdd-core/testing-tdd\` + \`python-dev/testing-python\`:

- RED: \`tests/test_runner_chain_halts_on_gate_failure.py\` 3 tests, fails on import (no module).
- GREEN: implement \`base/adapter.py\` + \`runner.py\` + \`stages/__init__.py\`.
- All 3 tests pass; full suite (54 tests) green.

Naming: \`test_{module}_{component}_{behavior}\`.

## Test plan

- [x] \`make test\` — 54 tests pass
- [x] \`make lint\` — ruff clean
- [x] \`make lint-md\` — clean
- [x] \`make lint-links\` — 152 links checked, 0 errors

## Out of scope (next PRs)

- PR 2: shared discover + Kreuzberg extract
- PR 3: shared markdown→DOCX/PDF render utility
- PR 4: V1 (Claude API) post-extraction stages
- PR 5: V2 (spaCy/Jinja2/DeepEval) post-extraction stages
- PR 6: parallel diff harness

Generated with Claude <noreply@anthropic.com>