### PR TITLE
chore(make): add test-rerun, test-fix-snapshots, validate targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,12 @@ enabled when §0.5 indexing wiring begins.
 | --- | --- |
 | `make test` | Full pytest suite |
 | `make test-contracts` | JSON schema round-trip tests only |
+| `make test-rerun` | Rerun only failed tests (`pytest --lf -x`) — fast TDD iteration |
+| `make test-fix-snapshots` | Auto-fix inline-snapshot expected values |
 | `make lint` | Ruff check on Python sources |
 | `make lint-md` | markdownlint on `**/*.md` (MD013 disabled) |
 | `make lint-links` | lychee link check |
+| `make validate` | Pre-commit gate: lint + test + lint-md + lint-links |
 | `make clean` | Remove `.pytest_cache`, `.ruff_cache`, `__pycache__` |
 | `make help` | List all recipes |
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .SILENT:
 .ONESHELL:
-.PHONY: install test test-contracts lint lint-md lint-links clean help
+.PHONY: install test test-contracts test-rerun test-fix-snapshots lint lint-md lint-links validate clean help
 .DEFAULT_GOAL := help
 
 VERBOSE ?=
@@ -27,6 +27,12 @@ test:  ## Run full test suite
 test-contracts:  ## JSON schema round-trip tests
 	uv run pytest tests/test_contracts.py -v
 
+test-rerun:  ## Rerun only failed tests (use during fix iterations)
+	uv run pytest --lf -x
+
+test-fix-snapshots:  ## Run tests and auto-fix inline-snapshot expected values
+	uv run pytest --inline-snapshot=fix
+
 lint:  ## Lint Python with ruff
 	echo "--- lint$(if $(RUFF_QUIET), [quiet])"
 	uv run ruff check $(RUFF_QUIET) .
@@ -46,6 +52,13 @@ lint-links:  ## Check links in Markdown (lychee, see lychee.toml)
 	else
 		echo "lychee not installed — see https://github.com/lycheeverse/lychee"
 	fi
+
+validate:  ## Pre-commit gate: lint + test + lint-md + lint-links
+	set -e
+	$(MAKE) -s lint
+	$(MAKE) -s test
+	$(MAKE) -s lint-md
+	$(MAKE) -s lint-links
 
 
 # MARK: CLEAN


### PR DESCRIPTION
## Summary

Adopt three patterns from the Agents-eval Makefile that complement the silent/verbose mode this repo already has:

- \`test-rerun\` — \`pytest --lf -x\` for fast TDD iteration after a failure
- \`test-fix-snapshots\` — \`pytest --inline-snapshot=fix\`; needed when V2 phase lands inline-snapshot regression tests
- \`validate\` — pre-commit gate chaining lint + test + lint-md + lint-links via \`\$(MAKE) -s\`; one command before pushing

Skipped (YAGNI for this codebase size): \`lint-src\`/\`lint-tests\` split, \`type-check\` (no pyright dep), \`complexity\`/\`duplication\` (no complexipy/jscpd).

\`CONTRIBUTING.md\` quality-commands table updated.

## Test plan

- [x] \`make validate\` runs and exits 0
- [x] \`make test-rerun\` runs (no-op when no prior failure cache)
- [x] \`make test-fix-snapshots\` available (no inline-snapshot tests yet; will be exercised at PR 5)

Generated with Claude <noreply@anthropic.com>