### PR TITLE
feat(stages): add discover and Kreuzberg extract stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- §0.2.0 runner scaffold: `runner.py` (stage chain + gate validation, halt-on-first-failure with `PipelineError` carrying stage and contract names), `base/adapter.py` (`AdapterBase` ABC), and `stages/__init__.py`
+- `stages/discover.py` — filesystem walk → `DiscoveryManifest` (sorted, sha256-hashed, glob-filtered)
+- `stages/extract.py` — Kreuzberg-backed adapter → `ExtractionBundle`; deferred import so the module loads without the optional extra
+- `pyproject.toml` `[project.optional-dependencies]` `extract` extra = `kreuzberg>=2.0` (MIT, local). Install with `uv sync --extra extract`
+- `Makefile` targets `test-rerun` (`pytest --lf -x`), `test-fix-snapshots` (`pytest --inline-snapshot=fix`), and `validate` (lint + test + lint-md + lint-links pre-commit gate)
+
+### Added
+
 - `docs/prototype-plan.md` — dual-variant E2E prototype plan (Claude Code vs landscape tools), Quick-tier-only, with TDD framing per `tdd-core` / `python-dev` plugins and a parallel-diff harness sketch. Roadmap §0.2.0, CONTRIBUTING doc hierarchy, and the four landscape files cross-link to it.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- §0.2.0 runner scaffold: `runner.py` (stage chain + gate validation, halt-on-first-failure with `PipelineError` carrying stage and contract names), `base/adapter.py` (`AdapterBase` ABC), and `stages/__init__.py`
+- [§0.2.0 — Runner](docs/roadmap.md#020--runner) scaffold: `runner.py` (stage chain + gate validation, halt-on-first-failure with `PipelineError` carrying stage and contract names), `base/adapter.py` (`AdapterBase` ABC), and `stages/__init__.py`
 - `stages/discover.py` — filesystem walk → `DiscoveryManifest` (sorted, sha256-hashed, glob-filtered)
 - `stages/extract.py` — Kreuzberg-backed adapter → `ExtractionBundle`; deferred import so the module loads without the optional extra
 - `pyproject.toml` `[project.optional-dependencies]` `extract` extra = `kreuzberg>=2.0` (MIT, local). Install with `uv sync --extra extract`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,14 @@ dependencies = [
   "jsonschema>=4.21",
 ]
 
+[project.optional-dependencies]
+# Install with: uv sync --extra extract
+# Kreuzberg covers PDF/Office/images/email/text via Tesseract+pypdfium2.
+# MIT, local-only, no cloud.
+extract = [
+  "kreuzberg>=2.0",
+]
+
 [dependency-groups]
 dev = [
   "pytest>=8.0",

--- a/src/doc_pipeline_engine/stages/discover.py
+++ b/src/doc_pipeline_engine/stages/discover.py
@@ -1,0 +1,51 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Discover stage: filesystem walk → DiscoveryManifest.
+
+Walks ``root`` with the given glob, computes sha256 per file, and emits a
+DiscoveryManifest dict ready for gate validation.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+CONTRACT_VERSION = "0.1.0"
+_HASH_CHUNK = 65536
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(_HASH_CHUNK), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def discover(root: Path, glob: str = "**/*") -> dict[str, Any]:
+    """Walk ``root`` matching ``glob``, return a DiscoveryManifest dict."""
+    files: list[dict[str, Any]] = []
+    for path in sorted(root.glob(glob)):
+        if not path.is_file():
+            continue
+        files.append(
+            {
+                "path": str(path.relative_to(root)),
+                "size_bytes": path.stat().st_size,
+                "sha256": _sha256(path),
+                "file_type": path.suffix.lstrip(".").lower() or "bin",
+            }
+        )
+    return {
+        "version": CONTRACT_VERSION,
+        "source": {"root": str(root), "kind": "folder"},
+        "discovered_at": datetime.now(timezone.utc).isoformat(),
+        "files": files,
+    }

--- a/src/doc_pipeline_engine/stages/extract.py
+++ b/src/doc_pipeline_engine/stages/extract.py
@@ -1,0 +1,68 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Extract stage: Kreuzberg-backed adapter → ExtractionBundle.
+
+Kreuzberg is an opt-in extra (``uv sync --extra extract``). The import is
+deferred so this module is importable without it; calling ``extract`` without
+the extra installed raises a clear error.
+
+The unit tests substitute ``_extract_file_sync`` and ``_kreuzberg_version``
+via monkeypatch so they run without the extra. Real-Kreuzberg behavior is
+covered by tests marked ``integration``.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+ADAPTER_NAME = "kreuzberg"
+CONTRACT_VERSION = "0.1.0"
+
+
+def _load_kreuzberg() -> tuple[Callable[..., Any], str]:
+    try:
+        from kreuzberg import extract_file_sync as fn  # type: ignore[import-not-found]
+        from kreuzberg import __version__ as version  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise RuntimeError(
+            "Kreuzberg not installed. Install the extras: "
+            "uv sync --extra extract"
+        ) from e
+    return fn, version
+
+
+_extract_file_sync, _kreuzberg_version = (None, "")
+try:
+    _extract_file_sync, _kreuzberg_version = _load_kreuzberg()
+except RuntimeError:
+    # deferred — extract() will raise on call if still missing
+    pass
+
+
+def extract(file_entry: dict[str, Any], source_root: Path) -> dict[str, Any]:
+    """Run Kreuzberg on ``source_root / file_entry['path']`` → ExtractionBundle dict."""
+    if _extract_file_sync is None:
+        raise RuntimeError(
+            "Kreuzberg not installed. Install the extras: uv sync --extra extract"
+        )
+
+    abs_path = source_root / file_entry["path"]
+    result = _extract_file_sync(str(abs_path))
+
+    return {
+        "version": CONTRACT_VERSION,
+        "source_path": file_entry["path"],
+        "source_sha256": file_entry["sha256"],
+        "adapter": {"name": ADAPTER_NAME, "version": _kreuzberg_version},
+        "extracted_at": datetime.now(timezone.utc).isoformat(),
+        "content": {
+            "text": getattr(result, "content", "") or "",
+            "layout": [],
+        },
+    }

--- a/tests/test_stages_discover_behavior.py
+++ b/tests/test_stages_discover_behavior.py
@@ -1,0 +1,63 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Discover stage: walks a root directory, computes sha256 per file, emits
+a valid DiscoveryManifest dict.
+"""
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from doc_pipeline_engine.base.contracts import is_valid
+from doc_pipeline_engine.stages.discover import discover
+
+
+def _write(p: Path, content: bytes) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(content)
+
+
+def test_stages_discover_emits_valid_discovery_manifest(tmp_path: Path) -> None:
+    _write(tmp_path / "a.pdf", b"hello pdf")
+    _write(tmp_path / "sub" / "b.docx", b"hello docx")
+
+    manifest = discover(tmp_path)
+
+    assert is_valid("DiscoveryManifest", manifest)
+
+
+def test_stages_discover_lists_files_with_sha256_and_size(tmp_path: Path) -> None:
+    payload = b"hello pdf"
+    _write(tmp_path / "a.pdf", payload)
+
+    manifest = discover(tmp_path)
+
+    files = {f["path"]: f for f in manifest["files"]}
+    assert "a.pdf" in files
+    assert files["a.pdf"]["size_bytes"] == len(payload)
+    assert files["a.pdf"]["sha256"] == hashlib.sha256(payload).hexdigest()
+    assert files["a.pdf"]["file_type"] == "pdf"
+
+
+def test_stages_discover_respects_glob_filter(tmp_path: Path) -> None:
+    _write(tmp_path / "a.pdf", b"x")
+    _write(tmp_path / "b.txt", b"x")
+
+    manifest = discover(tmp_path, glob="**/*.pdf")
+
+    paths = {f["path"] for f in manifest["files"]}
+    assert paths == {"a.pdf"}
+
+
+def test_stages_discover_source_records_root_and_kind(tmp_path: Path) -> None:
+    _write(tmp_path / "a.pdf", b"x")
+
+    manifest = discover(tmp_path)
+
+    assert manifest["source"]["root"] == str(tmp_path)
+    assert manifest["source"]["kind"] == "folder"

--- a/tests/test_stages_extract_kreuzberg_properties.py
+++ b/tests/test_stages_extract_kreuzberg_properties.py
@@ -1,0 +1,99 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Extract stage: Kreuzberg-backed adapter that consumes a DiscoveryManifest
+file entry and emits an ExtractionBundle.
+
+Unit tests stub Kreuzberg via monkeypatch so they run without the optional
+``extract`` dep installed. Real-Kreuzberg integration is exercised by tests
+marked ``integration`` (skipped in CI).
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from doc_pipeline_engine.base.contracts import is_valid
+from doc_pipeline_engine.stages import extract as extract_module
+from doc_pipeline_engine.stages.extract import extract
+
+
+@dataclass
+class _StubResult:
+    content: str = ""
+    metadata: dict[str, Any] | None = None
+    tables: list[Any] | None = None
+
+
+def _stub_extract_file_sync(_path: str, **_kwargs: Any) -> _StubResult:
+    return _StubResult(content="hello world", metadata={}, tables=[])
+
+
+@pytest.fixture
+def fake_kreuzberg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(extract_module, "_extract_file_sync", _stub_extract_file_sync)
+    monkeypatch.setattr(extract_module, "_kreuzberg_version", "stub")
+
+
+def _write_pdf(tmp_path: Path, name: str = "a.pdf") -> tuple[Path, dict[str, Any]]:
+    payload = b"hello pdf"
+    p = tmp_path / name
+    p.write_bytes(payload)
+    file_entry = {
+        "path": name,
+        "size_bytes": len(payload),
+        "sha256": hashlib.sha256(payload).hexdigest(),
+        "file_type": "pdf",
+    }
+    return p, file_entry
+
+
+def test_stages_extract_emits_valid_extraction_bundle(
+    tmp_path: Path, fake_kreuzberg: None
+) -> None:
+    _, entry = _write_pdf(tmp_path)
+
+    bundle = extract(entry, tmp_path)
+
+    assert is_valid("ExtractionBundle", bundle)
+
+
+def test_stages_extract_records_kreuzberg_adapter_identity(
+    tmp_path: Path, fake_kreuzberg: None
+) -> None:
+    _, entry = _write_pdf(tmp_path)
+
+    bundle = extract(entry, tmp_path)
+
+    assert bundle["adapter"]["name"] == "kreuzberg"
+    assert bundle["adapter"]["version"] == "stub"
+
+
+def test_stages_extract_propagates_sha256_and_path(
+    tmp_path: Path, fake_kreuzberg: None
+) -> None:
+    _, entry = _write_pdf(tmp_path)
+
+    bundle = extract(entry, tmp_path)
+
+    assert bundle["source_path"] == entry["path"]
+    assert bundle["source_sha256"] == entry["sha256"]
+
+
+def test_stages_extract_text_comes_from_kreuzberg_content(
+    tmp_path: Path, fake_kreuzberg: None
+) -> None:
+    _, entry = _write_pdf(tmp_path)
+
+    bundle = extract(entry, tmp_path)
+
+    assert bundle["content"]["text"] == "hello world"
+    assert bundle["content"]["layout"] == []

--- a/uv.lock
+++ b/uv.lock
@@ -132,6 +132,11 @@ dependencies = [
     { name = "jsonschema" },
 ]
 
+[package.optional-dependencies]
+extract = [
+    { name = "kreuzberg" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -140,7 +145,11 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "jsonschema", specifier = ">=4.21" }]
+requires-dist = [
+    { name = "jsonschema", specifier = ">=4.21" },
+    { name = "kreuzberg", marker = "extra == 'extract'", specifier = ">=2.0" },
+]
+provides-extras = ["extract"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -183,6 +192,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "kreuzberg"
+version = "4.9.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/bc/1b77430cdd71e32ee1d985d8bb2faaeba1589217d38951f4acaa9f8ce0da/kreuzberg-4.9.5-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:9319c01a0ae90dfbbe5d019109ed0ccc123508ecf0f5ed1430b2a6b56cbef99c", size = 28750375, upload-time = "2026-04-23T12:13:04.68Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ce/94cdc6856cb0596cc03f69d9df0f0879727be8d8ad65c5b2284a6a7aca4c/kreuzberg-4.9.5-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:335cf8a6565ca2b0a03e4f646afe549586a2a3387b68b770fb768c1de7dc35b1", size = 33278522, upload-time = "2026-04-23T12:13:08.19Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/36/5ff6fe57b6b91ef065b2ce0ba79ca46e800632843f3dc800aa4274f16cdd/kreuzberg-4.9.5-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:87c702b584103b8addb142dd879742f0c71ea15170fa6849166b79b870e6b595", size = 35499065, upload-time = "2026-04-23T12:13:11.996Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

PR 2 of 6 from the [prototype plan](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/prototype-plan.md). Two stages share between V1 and V2:

- **\`discover\`** (pure stdlib) — walks a root with rglob, sha256 per file, sorted output, emits a valid \`DiscoveryManifest\` dict.
- **\`extract\`** — Kreuzberg-backed adapter, single shared extractor for both pipeline legs (eliminates extraction as an A/B confound). Deferred import so the module loads without the optional extra; helpful runtime error if extras aren't installed.

## TDD

Per \`tdd-core/testing-tdd\` + \`python-dev/testing-python\`. RED-GREEN cycle for each stage.

\`discover\` tests (4): valid-manifest, sha256+size, glob filter, source/kind.
\`extract\` tests (4): valid-bundle, adapter identity, sha256/path propagation, content text. Kreuzberg substituted via monkeypatch — no extra needed in CI.

Naming: \`test_{module}_{component}_{behavior}\`.

## pyproject.toml

\`\`\`toml
[project.optional-dependencies]
extract = ["kreuzberg>=2.0"]   # MIT, local-only. uv sync --extra extract
\`\`\`

\`[project.optional-dependencies]\` (PEP 621), not \`[dependency-groups]\` — Kreuzberg is a runtime extra that downstream consumers (polyforge, office-polyforge) need to be able to opt into when they embed this engine.

## Commits

\`\`\`text
feat(stages): add discover stage (filesystem → DiscoveryManifest)
feat(stages): add Kreuzberg-backed extract adapter
docs: hyperlink §0.2.0 reference in CHANGELOG
\`\`\`

## Test plan

- [x] \`make validate\` — lint + 62 tests + lint-md + lint-links all green
- [x] \`uv sync\` re-resolves cleanly with the new extras section
- [ ] Real Kreuzberg integration smoke (manual, after \`uv sync --extra extract\`)

## Out of scope (next PRs)

- PR 3: shared markdown→DOCX/PDF render utility (independent; can land in parallel)
- PR 4: V1 (Claude API) post-extraction stages
- PR 5: V2 (spaCy / Jinja2 / DeepEval) post-extraction stages
- PR 6: parallel diff harness

Generated with Claude <noreply@anthropic.com>