### PR TITLE
chore(pyproject): use SPDX string for license per PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Modular document processing engine with contract-gated pipeline stages"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 dependencies = [
   "jsonschema>=4.21",


### PR DESCRIPTION
## Summary

The PEP 621 table form \`license = { text = "Apache-2.0" }\` is deprecated and emits a validation warning (\`'{"text":"Apache-2.0"}' is not of type "string"'\`). PEP 639 wants a plain SPDX expression.

\`\`\`diff
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
\`\`\`

\`license-files\` unchanged.

## Test plan

- [x] \`uv sync\` resolves cleanly
- [x] \`make validate\` — lint + 68 tests + lint-md + lint-links all green
- [x] No metadata-related warnings

Generated with Claude <noreply@anthropic.com>