### PR TITLE
chore(ci): add SBOM and llms.txt workflows via qte77 actions

### DIFF
--- a/.github/templates/llms.txt.tpl
+++ b/.github/templates/llms.txt.tpl
@@ -1,0 +1,31 @@
+# ${PROJECT_NAME}
+
+> ${PROJECT_DESC}
+
+## Getting Started
+
+- [README](${BLOB}/README.md): Project overview and quickstart
+- [Contributing](${BLOB}/CONTRIBUTING.md): Setup, quality commands, plugins, optional extras
+
+## Architecture & Design
+
+- [Architecture](${BLOB}/docs/architecture.md): Stage graph, contracts, runtime modes, design decisions
+- [Roadmap](${BLOB}/docs/roadmap.md): Versioned milestones (0.1 → 0.6+)
+- [Prototype plan](${BLOB}/docs/prototype-plan.md): Dual-variant E2E prototype (Claude vs Python tools)
+
+## Tool surveys
+
+- [Landscape — Ingest](${BLOB}/docs/landscape-ingest.md): Extraction backends, source connectors, crawling
+- [Landscape — Process](${BLOB}/docs/landscape-process.md): Chunking, NER, RAG indexing, normalization
+- [Landscape — Output](${BLOB}/docs/landscape-output.md): Rendering, office formats, templating, conformance
+- [Landscape — Prior art](${BLOB}/docs/landscape-prior-art.md): E2E pipeline competitors and USP positioning
+
+## Governance
+
+- [Agent rules](${BLOB}/AGENTS.md): AI-agent behavioral rules and quality thresholds
+- [Agent learnings](${BLOB}/AGENT_LEARNINGS.md): Compound learnings across sessions
+- [Agent requests](${BLOB}/AGENT_REQUESTS.md): Open escalations from agents
+
+## Optional
+
+- [Changelog](${BLOB}/CHANGELOG.md): Release history (Keep a Changelog)

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -1,0 +1,26 @@
+name: Generate SBOM
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/SBOM/**"
+  schedule:
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Generate SBOM
+        uses: qte77/gha-sbom-action@82becb244dc8ec442a17d5b5e171d0a384909896 # v0.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/write-llms-txt.yaml
+++ b/.github/workflows/write-llms-txt.yaml
@@ -1,0 +1,28 @@
+name: Write repo llms.txt
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/templates/llms.txt.tpl"
+      - "src/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "AGENTS.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  generate-file:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Generate llms.txt
+        uses: qte77/gha-llms-txt-action@7cb4f03bd69a23c0e561ce76e926cadc0d3d3b9f # v0.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.github/workflows/generate-sbom.yaml` — calls `qte77/gha-sbom-action@v0.1.0` on weekly cron + push-to-main; outputs SPDX SBOM to `docs/SBOM/`
+- `.github/workflows/write-llms-txt.yaml` — calls `qte77/gha-llms-txt-action@v0.1.0`; auto-generates `docs/llms.txt` from `.github/templates/llms.txt.tpl` whenever docs/src/governance change
+- `.github/templates/llms.txt.tpl` — llms.txt index template covering architecture, roadmap, prototype-plan, four landscape docs, and governance files
+
+### Added
+
 - [§0.2.0 — Runner](docs/roadmap.md#020--runner) scaffold: `runner.py` (stage chain + gate validation, halt-on-first-failure with `PipelineError` carrying stage and contract names), `base/adapter.py` (`AdapterBase` ABC), and `stages/__init__.py`
 - `stages/discover.py` — filesystem walk → `DiscoveryManifest` (sorted, sha256-hashed, glob-filtered)
 - `stages/extract.py` — Kreuzberg-backed adapter → `ExtractionBundle`; deferred import so the module loads without the optional extra


### PR DESCRIPTION
## Summary

Adopt the [qte77/so101-biolab-automation](https://github.com/qte77/so101-biolab-automation) pattern: thin workflow files that call qte77's reusable composite actions, pinned to commit SHAs for supply-chain integrity.

| File | Calls | Cadence |
|---|---|---|
| \`.github/workflows/generate-sbom.yaml\` | \`qte77/gha-sbom-action@v0.1.0\` | Weekly cron + push-to-main |
| \`.github/workflows/write-llms-txt.yaml\` | \`qte77/gha-llms-txt-action@v0.1.0\` | On docs/src/governance change |
| \`.github/templates/llms.txt.tpl\` | (template, consumed by gha-llms-txt-action) | — |

### What each gives us

- **SBOM**: SPDX outputs from both GitHub's dependency graph and Syft filesystem scan, plus a human-readable \`docs/SBOM/sbom.md\`. Aligns with the project's "license isolation as USP" stance — surfaces transitive license drift.
- **llms.txt**: spec-compliant index per [llmstxt.org](https://llmstxt.org/) covering architecture, roadmap, prototype-plan, four landscape docs, and governance files. Lets agents and humans alike navigate the repo without crawling.

### Why reusable actions over inlined workflow logic

- Single source of truth for the SBOM/llms.txt logic (across qte77 repos).
- Pinned commit SHAs mean a vetted version, not a moving \`@main\`.
- Repo-local workflow stays under 25 lines each.

\`codeql.yaml\` and \`dependabot.yaml\` are already byte-equivalent to the canonical qte77 template (verified against Agents-eval) — no change needed there.

## Test plan

- [x] \`make validate\` — lint + 92 tests + lint-md + lint-links all green
- [x] llms.txt template references only files that exist in the repo
- [ ] Workflows trigger correctly on next push to main (will verify post-merge)

Generated with Claude <noreply@anthropic.com>