### PR TITLE
feat(harness): parallel V1/V2 diff harness — final prototype piece

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `pyproject.toml` `[project.optional-dependencies]` `v2 = [jinja2, spacy]`, `v2-render = [jinja2]` (subset for Python 3.14 envs without spaCy wheels), `v2-eval = [deepeval]` (wired by PR 6 harness).
 - `Makefile` `install-models` target — `uv run python -m spacy download en_core_web_sm` (needed for V2 NER).
 - `CONTRIBUTING.md` documents the full extras taxonomy with locality flags.
+- Parallel diff harness — `harness.py` with `run_both(sample_path, ...)` returning a `DiffReport` (`LegResult` per variant: contracts, RenderArtifacts, wall_times, eval_report). Extraction is shared (Kreuzberg runs once); only post-extraction stages diverge per leg. CLI: `python -m doc_pipeline_engine.harness <sample> [--output-dir DIR]`. Renders md/docx/pdf to `outputs/<sha256>/v1/` and `outputs/<sha256>/v2/`.
+- `docs/prototype-samples.md` — selection criteria for the five prototype samples (one per use case: bidtender / legal / invoice / spec / diagrams).
+- `docs/prototype-results.md` — placeholder for first-run eval results across the five eval axes (faithfulness, determinism, latency, cost, layout fidelity).
 - `Makefile` targets `test-rerun` (`pytest --lf -x`), `test-fix-snapshots` (`pytest --inline-snapshot=fix`), and `validate` (lint + test + lint-md + lint-links pre-commit gate)
 
 ### Added

--- a/docs/prototype-results.md
+++ b/docs/prototype-results.md
@@ -1,0 +1,40 @@
+# Prototype results
+
+Outputs of the [parallel diff harness](prototype-plan.md) running both
+V1 (Claude API) and V2 (Python tools) legs on the [prototype
+samples](prototype-samples.md).
+
+## Status
+
+**Not yet populated.** The harness lands in PR 6; first real run requires
+`uv sync --extra extract --extra render --extra v1 --extra v2-render`,
+`ANTHROPIC_API_KEY` in env, and the samples downloaded via
+`bash scripts/download-samples.sh --download`.
+
+## Run procedure
+
+```bash
+# One sample
+uv run python -m doc_pipeline_engine.harness samples/contracts/<file>.pdf \
+  --output-dir outputs/
+
+# Per-sample DiffReport JSON is emitted to stdout; rendered artifacts
+# (md / docx / pdf for both legs) are written under outputs/<sha256>/.
+```
+
+## Eval axes (recap)
+
+Per [prototype-plan.md → Eval axes](prototype-plan.md#eval-axes):
+
+1. **Faithfulness** — V1 vs V2 summary contradicts source?
+2. **Determinism** — re-run consistency
+3. **Latency** — wall-clock per leg per stage
+4. **Cost** — Claude API tokens (V1) vs compute seconds (V2)
+5. **Layout fidelity** — table/figure preservation (matters for Comprehensive tier)
+
+## Results — first run
+
+*Pending.*
+
+This file is updated by hand after the first end-to-end run on all
+five prototype samples.

--- a/docs/prototype-samples.md
+++ b/docs/prototype-samples.md
@@ -1,0 +1,26 @@
+# Prototype sample selection
+
+Five samples drive the v1 [E2E prototype](prototype-plan.md), one per
+use case, covering the file-type spectrum (PDF, DOCX, XLSX, text, image).
+Sample binaries are gitignored; obtain them with:
+
+```bash
+bash scripts/download-samples.sh --download
+```
+
+## Selection criteria
+
+| Use case | Format | `samples/` category | Why |
+| --- | --- | --- | --- |
+| Bidtender / contract | PDF | `contracts/` | Long-form structured prose; multi-section headings test normalize |
+| Legal | PDF | `legal/us/` | Citation-rich, formal language; tests claim extraction |
+| Invoice | PDF or image | `invoices/` | Tabular content + small text blocks; table-extraction stress |
+| Spec / certification | PDF + DOCX | `mech-elec-cert/` | Heading hierarchy + technical terms; multi-format A/B |
+| Diagrams / scanned | image / scanned PDF | `generic/` | Layout-only or image-only; OCR path stress |
+
+## Locking the five filenames
+
+Concrete filenames are confirmed at first harness run. Until then, the
+selection criteria above stand in. After the first run, this file gets
+updated with the exact paths and sha256 of each sample, and the eval
+results land in [prototype-results.md](prototype-results.md).

--- a/src/doc_pipeline_engine/harness.py
+++ b/src/doc_pipeline_engine/harness.py
@@ -1,0 +1,195 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Parallel diff harness: run V1 and V2 legs on the same sample and diff.
+
+Extraction is shared between legs (Kreuzberg runs once); only the post-
+extraction stages diverge. The DiffReport captures both legs' contracts,
+timings, costs, eval reports, and a small set of comparative axes.
+
+Usage (CLI):
+    python -m doc_pipeline_engine.harness <sample_path> [--output-dir DIR]
+
+Both ``v1`` and ``extract`` extras must be installed for real runs:
+    uv sync --extra extract --extra render --extra v1 --extra v2-render
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from doc_pipeline_engine.render.formats import RenderArtifacts
+
+
+@dataclass
+class LegResult:
+    variant: str  # "v1" | "v2"
+    contracts: list[dict[str, Any]]  # all stage outputs in order
+    artifacts: RenderArtifacts
+    wall_times: dict[str, float]
+    eval_report: dict[str, Any]
+
+
+@dataclass
+class DiffReport:
+    sample_path: str
+    sample_sha256: str
+    extraction_bundle: dict[str, Any]
+    v1: LegResult
+    v2: LegResult
+    axes: dict[str, float] = field(default_factory=dict)
+
+
+def _time(fn: Any, *args: Any, **kwargs: Any) -> tuple[Any, float]:
+    t0 = time.perf_counter()
+    out = fn(*args, **kwargs)
+    return out, time.perf_counter() - t0
+
+
+def _run_v1_leg(bundle: dict[str, Any], v1_model: str) -> LegResult:
+    from doc_pipeline_engine.stages.v1_analyze import analyze_v1
+    from doc_pipeline_engine.stages.v1_eval import eval_v1
+    from doc_pipeline_engine.stages.v1_normalize import normalize_v1
+    from doc_pipeline_engine.stages.v1_render import render_v1
+
+    times: dict[str, float] = {}
+    canonical, times["normalize"] = _time(normalize_v1, bundle, model=v1_model)
+    report, times["analyze"] = _time(analyze_v1, canonical, model=v1_model)
+    artifacts, times["render"] = _time(render_v1, report, model=v1_model)
+    eval_report, times["eval"] = _time(eval_v1, bundle, canonical, report, artifacts)
+    return LegResult(
+        variant="v1",
+        contracts=[canonical, report, eval_report],
+        artifacts=artifacts,
+        wall_times=times,
+        eval_report=eval_report,
+    )
+
+
+def _run_v2_leg(bundle: dict[str, Any]) -> LegResult:
+    from doc_pipeline_engine.stages.v2_analyze import analyze_v2
+    from doc_pipeline_engine.stages.v2_eval import eval_v2
+    from doc_pipeline_engine.stages.v2_normalize import normalize_v2
+    from doc_pipeline_engine.stages.v2_render import render_v2
+
+    times: dict[str, float] = {}
+    canonical, times["normalize"] = _time(normalize_v2, bundle)
+    report, times["analyze"] = _time(analyze_v2, canonical)
+    artifacts, times["render"] = _time(render_v2, report)
+    eval_report, times["eval"] = _time(eval_v2, bundle, canonical, report, artifacts)
+    return LegResult(
+        variant="v2",
+        contracts=[canonical, report, eval_report],
+        artifacts=artifacts,
+        wall_times=times,
+        eval_report=eval_report,
+    )
+
+
+def _compute_axes(v1: LegResult, v2: LegResult) -> dict[str, float]:
+    """Comparative axes between V1 and V2 results."""
+    v1_total = sum(v1.wall_times.values())
+    v2_total = sum(v2.wall_times.values())
+    return {
+        "v1_total_seconds": v1_total,
+        "v2_total_seconds": v2_total,
+        "latency_ratio_v1_over_v2": v1_total / v2_total if v2_total > 0 else 0.0,
+    }
+
+
+def _write_artifacts(out_dir: Path, sha: str, variant: str, art: RenderArtifacts) -> None:
+    sub = out_dir / sha / variant
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "summary.md").write_text(art.md)
+    (sub / "summary.docx").write_bytes(art.docx)
+    (sub / "summary.pdf").write_bytes(art.pdf)
+
+
+def run_both(
+    sample_path: Path,
+    *,
+    v1_model: str = "claude-opus-4-7",
+    output_dir: Path | None = None,
+) -> DiffReport:
+    """Discover + extract the sample once, then run both legs and diff."""
+    from doc_pipeline_engine.stages.discover import discover
+    from doc_pipeline_engine.stages.extract import extract
+
+    root = sample_path.parent
+    manifest = discover(root, glob=sample_path.name)
+    files = manifest["files"]
+    if not files:
+        raise FileNotFoundError(f"no files matched at {sample_path}")
+    file_entry = files[0]
+    bundle = extract(file_entry, root)
+
+    v1 = _run_v1_leg(bundle, v1_model=v1_model)
+    v2 = _run_v2_leg(bundle)
+    axes = _compute_axes(v1, v2)
+
+    report = DiffReport(
+        sample_path=str(sample_path),
+        sample_sha256=file_entry["sha256"],
+        extraction_bundle=bundle,
+        v1=v1,
+        v2=v2,
+        axes=axes,
+    )
+
+    if output_dir is not None:
+        out = Path(output_dir)
+        _write_artifacts(out, file_entry["sha256"], "v1", v1.artifacts)
+        _write_artifacts(out, file_entry["sha256"], "v2", v2.artifacts)
+
+    return report
+
+
+def _to_json(report: DiffReport) -> dict[str, Any]:
+    """Serialise DiffReport to a JSON-safe dict; artifact bytes omitted."""
+    def leg(r: LegResult) -> dict[str, Any]:
+        return {
+            "variant": r.variant,
+            "contracts": r.contracts,
+            "wall_times": r.wall_times,
+            "eval_report": r.eval_report,
+            "artifacts": {"md_chars": len(r.artifacts.md),
+                          "docx_bytes": len(r.artifacts.docx),
+                          "pdf_bytes": len(r.artifacts.pdf)},
+        }
+    return {
+        "sample_path": report.sample_path,
+        "sample_sha256": report.sample_sha256,
+        "extraction_bundle": report.extraction_bundle,
+        "v1": leg(report.v1),
+        "v2": leg(report.v2),
+        "axes": report.axes,
+    }
+
+
+def _cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run V1 + V2 legs on one sample.")
+    parser.add_argument("sample", type=Path, help="Path to a single sample file")
+    parser.add_argument("--output-dir", type=Path, default=None,
+                        help="Write rendered md/docx/pdf artifacts under this dir")
+    parser.add_argument("--v1-model", default="claude-opus-4-7")
+    args = parser.parse_args(argv)
+    report = run_both(args.sample, v1_model=args.v1_model, output_dir=args.output_dir)
+    json.dump(_to_json(report), sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())
+
+
+__all__ = ["DiffReport", "LegResult", "run_both"]

--- a/tests/test_harness_diff_both_variants.py
+++ b/tests/test_harness_diff_both_variants.py
@@ -1,0 +1,190 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Diff harness tests with both legs mocked.
+
+Real V1 calls Anthropic; real V2 needs render extras. We mock both via
+monkeypatch and assert the harness's own behaviour: shape of DiffReport,
+artifact write-out, axes computation, JSON serialisation.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("docx")
+pytest.importorskip("markdown")
+pytest.importorskip("weasyprint")
+
+from doc_pipeline_engine.harness import (  # noqa: E402
+    DiffReport,
+    LegResult,
+    _to_json,
+    run_both,
+)
+from doc_pipeline_engine.render.formats import RenderArtifacts  # noqa: E402
+from doc_pipeline_engine.stages import extract as extract_module  # noqa: E402
+
+SHA = "0" * 64
+
+
+def _stub_extract_file_sync(_path: str, **_kwargs: object) -> object:
+    class R:
+        content = "Hello world. Some body."
+        metadata: dict = {}
+        tables: list = []
+    return R()
+
+
+@pytest.fixture
+def fake_kreuzberg(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(extract_module, "_extract_file_sync", _stub_extract_file_sync)
+    monkeypatch.setattr(extract_module, "_kreuzberg_version", "stub")
+
+
+@pytest.fixture
+def fake_v1(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace V1 stage functions with deterministic stubs."""
+    valid_canonical = {
+        "version": "0.1.0",
+        "source_sha256": SHA,
+        "built_at": "2026-04-26T00:00:00+00:00",
+        "root": {"id": "s.0", "level": 0, "kind": "doc", "text": ""},
+        "tier_summary": {"l0": "summary", "l1": "longer summary"},
+    }
+    valid_report = {
+        "version": "0.1.0",
+        "source_sha256": SHA,
+        "analyzed_at": "2026-04-26T00:00:00+00:00",
+        "claims": [{"id": "c1", "text": "x is y", "node_refs": ["s.0"]}],
+        "entities": [],
+    }
+    valid_eval = {
+        "version": "0.1.0",
+        "evaluated_at": "2026-04-26T00:00:00+00:00",
+        "tier": "quick",
+        "verdict": "pass",
+        "scores": {"schema_valid": {"value": 1.0, "threshold": 1.0, "passed": True}},
+    }
+    artifacts = RenderArtifacts(md="# v1 md", docx=b"PK\x03\x04", pdf=b"%PDF-stub")
+
+    monkeypatch.setattr(
+        "doc_pipeline_engine.stages.v1_normalize.normalize_v1",
+        lambda bundle, **_: valid_canonical,
+    )
+    monkeypatch.setattr(
+        "doc_pipeline_engine.stages.v1_analyze.analyze_v1",
+        lambda canonical, **_: valid_report,
+    )
+    monkeypatch.setattr(
+        "doc_pipeline_engine.stages.v1_render.render_v1",
+        lambda report, **_: artifacts,
+    )
+    monkeypatch.setattr(
+        "doc_pipeline_engine.stages.v1_eval.eval_v1",
+        lambda *args, **_: valid_eval,
+    )
+
+
+def _write_sample(tmp_path: Path) -> Path:
+    p = tmp_path / "a.pdf"
+    p.write_bytes(b"hello pdf")
+    return p
+
+
+def test_harness_run_both_returns_diff_report(
+    tmp_path: Path, fake_kreuzberg: None, fake_v1: None
+) -> None:
+    sample = _write_sample(tmp_path)
+
+    report = run_both(sample)
+
+    assert isinstance(report, DiffReport)
+    assert report.sample_sha256 != ""
+    assert isinstance(report.v1, LegResult)
+    assert isinstance(report.v2, LegResult)
+
+
+def test_harness_v1_and_v2_legs_each_emit_three_post_extraction_contracts(
+    tmp_path: Path, fake_kreuzberg: None, fake_v1: None
+) -> None:
+    sample = _write_sample(tmp_path)
+
+    report = run_both(sample)
+
+    # post-extraction contracts: canonical, analysis, eval
+    assert len(report.v1.contracts) == 3
+    assert len(report.v2.contracts) == 3
+
+
+def test_harness_extraction_bundle_is_shared_between_legs(
+    tmp_path: Path, fake_kreuzberg: None, fake_v1: None
+) -> None:
+    sample = _write_sample(tmp_path)
+
+    report = run_both(sample)
+
+    # Real extraction bundle from Kreuzberg (stubbed) — single source of truth.
+    assert report.extraction_bundle["adapter"]["name"] == "kreuzberg"
+    assert report.extraction_bundle["source_sha256"] == report.sample_sha256
+    # V2 (deterministic) propagates sha256 from the bundle into its canonical doc.
+    # V1 is stubbed here with a placeholder sha256, so we don't equality-check it
+    # against the bundle — that's covered by the real-API integration test.
+    assert report.v2.contracts[0]["source_sha256"] == report.extraction_bundle["source_sha256"]
+
+
+def test_harness_axes_includes_latency_ratio(
+    tmp_path: Path, fake_kreuzberg: None, fake_v1: None
+) -> None:
+    sample = _write_sample(tmp_path)
+
+    report = run_both(sample)
+
+    assert "v1_total_seconds" in report.axes
+    assert "v2_total_seconds" in report.axes
+    assert "latency_ratio_v1_over_v2" in report.axes
+
+
+def test_harness_writes_artifacts_to_output_dir_when_given(
+    tmp_path: Path, fake_kreuzberg: None, fake_v1: None
+) -> None:
+    sample = _write_sample(tmp_path)
+    out = tmp_path / "outputs"
+
+    report = run_both(sample, output_dir=out)
+
+    sha_dir = out / report.sample_sha256
+    assert (sha_dir / "v1" / "summary.md").exists()
+    assert (sha_dir / "v1" / "summary.docx").exists()
+    assert (sha_dir / "v1" / "summary.pdf").exists()
+    assert (sha_dir / "v2" / "summary.md").exists()
+
+
+def test_harness_to_json_omits_artifact_bytes(
+    tmp_path: Path, fake_kreuzberg: None, fake_v1: None
+) -> None:
+    sample = _write_sample(tmp_path)
+    report = run_both(sample)
+
+    payload = _to_json(report)
+
+    assert payload["v1"]["artifacts"]["md_chars"] > 0
+    assert payload["v1"]["artifacts"]["docx_bytes"] > 0
+    assert payload["v1"]["artifacts"]["pdf_bytes"] > 0
+    # Bytes themselves are not in the JSON payload (would not be serialisable
+    # cleanly and would bloat output).
+    assert "docx" not in payload["v1"]["artifacts"]
+
+
+def test_harness_run_both_raises_when_sample_missing(
+    tmp_path: Path, fake_kreuzberg: None, fake_v1: None
+) -> None:
+    missing = tmp_path / "nope.pdf"
+
+    with pytest.raises(FileNotFoundError):
+        run_both(missing)


### PR DESCRIPTION
## Summary

PR 6 of 6 from the [prototype plan](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/prototype-plan.md). Closes the loop: run both V1 and V2 legs on the same sample and emit a comparative \`DiffReport\`.

### Architecture

\`\`\`text
sample.pdf ──► discover ──► Kreuzberg extract ──► ExtractionBundle (shared)
                                                       │
                          ┌────────────────────────────┴────────────────────────┐
                          ▼                                                     ▼
              normalize_v1 → analyze_v1 → render_v1 → eval_v1     normalize_v2 → analyze_v2 → render_v2 → eval_v2
                          │                                                     │
                          └────────────────────► DiffReport ◄──────────────────┘
\`\`\`

### Public API

\`\`\`python
@dataclass
class LegResult:
    variant: str          # "v1" | "v2"
    contracts: list[dict] # canonical, analysis, eval
    artifacts: RenderArtifacts
    wall_times: dict[str, float]
    eval_report: dict

@dataclass
class DiffReport:
    sample_path: str
    sample_sha256: str
    extraction_bundle: dict
    v1: LegResult
    v2: LegResult
    axes: dict[str, float]   # v1_total_seconds, v2_total_seconds, latency_ratio_v1_over_v2

def run_both(sample_path, *, v1_model="claude-opus-4-7", output_dir=None) -> DiffReport
\`\`\`

### CLI

\`\`\`bash
uv run python -m doc_pipeline_engine.harness samples/contracts/<file>.pdf \\
    --output-dir outputs/

# JSON DiffReport to stdout; rendered artifacts (md / docx / pdf for both
# legs) under outputs/<sha256>/v1/ and outputs/<sha256>/v2/.
\`\`\`

## Tests (TDD)

7 new tests, V1 + Kreuzberg both stubbed via monkeypatch — runs without
\`ANTHROPIC_API_KEY\`, without the \`extract\` extra:

- DiffReport shape
- Three post-extraction contracts per leg
- Shared extraction bundle
- Axes contents
- Artifact write-out under \`output_dir\`
- JSON serialisation omits artifact bytes
- \`FileNotFoundError\` when sample missing

## New docs

- \`docs/prototype-samples.md\` — selection criteria for the five v1 samples (one per use case). Concrete filenames lock at first run.
- \`docs/prototype-results.md\` — placeholder for first-run eval results.

## Commits

\`\`\`text
feat(harness): parallel V1/V2 diff harness on a single sample
docs: prototype-samples and prototype-results placeholders
\`\`\`

## Test plan

- [x] \`make validate\` — lint + 99 tests + lint-md + lint-links all green
- [ ] First real end-to-end run — manual; needs \`uv sync --extra extract --extra render --extra v1 --extra v2-render\`, \`ANTHROPIC_API_KEY\` in env, samples downloaded via \`bash scripts/download-samples.sh --download\`, then \`uv run python -m doc_pipeline_engine.harness ...\`. Results captured in \`docs/prototype-results.md\` after the run.

## Phase status

This closes the **prototype scaffolding work**. After merge, the next deliverable is the **first real run** on five samples and the captured comparison in \`prototype-results.md\` — that's a manual operation, not a code-change PR.

Generated with Claude <noreply@anthropic.com>