### PR TITLE
fix(ci): set create_pr=false on SBOM and llms.txt workflows

### DIFF
--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -24,3 +24,6 @@ jobs:
         uses: qte77/gha-sbom-action@82becb244dc8ec442a17d5b5e171d0a384909896 # v0.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The repo's GitHub Actions permissions don't allow PR creation.
+          # Push directly to main; SBOM updates are scheduled and don't need review.
+          create_pr: false

--- a/.github/workflows/write-llms-txt.yaml
+++ b/.github/workflows/write-llms-txt.yaml
@@ -26,3 +26,6 @@ jobs:
         uses: qte77/gha-llms-txt-action@7cb4f03bd69a23c0e561ce76e926cadc0d3d3b9f # v0.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The repo's GitHub Actions permissions don't allow PR creation.
+          # Push directly to main; llms.txt updates are auto-generated docs.
+          create_pr: false


### PR DESCRIPTION
## Summary

Both workflows from PR #23 failed on first run with:

\`\`\`
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
\`\`\`

The repo's "Allow GitHub Actions to create and approve pull requests" setting is disabled. Two ways to fix:

1. **Settings UI** (Settings → Actions → General → Workflow permissions) — persistent but manual.
2. **Override \`create_pr: false\`** in our workflow calls — push directly to main; SBOM/llms.txt updates are scheduled and don't need review.

This PR takes option 2. The workflows already have \`contents: write\` so direct push works.

## Failed runs

- \`Generate SBOM\` run [24965137557](https://github.com/qte77/doc-pipeline-engine/actions/runs/24965137557)
- \`Write repo llms.txt\` run [24965137542](https://github.com/qte77/doc-pipeline-engine/actions/runs/24965137542)

## Test plan

- [x] \`make lint-md\` clean
- [ ] Workflows succeed on next push to main (verify post-merge)

## Cleanup

The first failed run also created stale branches \`auto/sbom-update-*\` and \`auto/llms-txt-update-*\` on origin. I'll prune those after this lands.

Generated with Claude <noreply@anthropic.com>