### PR TITLE
docs: prototype first-run results, docs reorg, frontmatter governance

### DIFF
--- a/.claude/rules/frontmatter-convention.md
+++ b/.claude/rules/frontmatter-convention.md
@@ -1,0 +1,78 @@
+---
+paths:
+  - "**/*.md"
+---
+
+# Frontmatter Convention
+
+Every markdown file MUST have YAML frontmatter unless it is an exempt file.
+
+## Required Fields
+
+```yaml
+---
+title: Descriptive Title
+purpose: One-line purpose statement
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+validated_links: YYYY-MM-DD
+---
+```
+
+- `title` — descriptive, matches the `# H1` heading
+- `purpose` — one line, used for relevance matching and context decisions
+- `created` — date of first commit
+- `updated` — bump on every content edit
+- `validated_links` — date when URLs were last verified working
+
+## Optional Fields
+
+- `source` — primary URL the doc is based on
+- `category` — `technical`, `requirements`, `implementation`, `landscape`
+
+## Exempt Files
+
+These follow their own conventions — no YAML frontmatter required:
+
+### Well-Known Project Files
+
+`README.md`, `CHANGELOG.md`, `LICENSE.md`, `CONTRIBUTING.md`, `AGENTS.md`,
+`CODE_OF_CONDUCT.md`, `SECURITY.md`, `TODO.md`, `LEARNINGS.md`, `REQUESTS.md`,
+`CODEOWNERS`, `.gitmessage`
+
+### GitHub Templates
+
+Files in `.github/` — issue templates, PR templates, and workflow files use
+their own YAML frontmatter format (`name`, `description`, `labels`, etc.).
+
+### Build/Config Markdown
+
+`mkdocs.yml`-referenced nav files, `docs/index.md` (if auto-generated).
+
+## Markdownlint Compatibility
+
+Frontmatter **must be on line 1**. No HTML comments (`<!-- -->`) before the
+opening `---` — this breaks markdownlint's frontmatter parser and causes
+false MD041 (first-line-heading) and MD003 (heading-style) errors.
+
+### Required `.markdownlint.json` config
+
+```json
+{
+  "MD013": false,
+  "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" }
+}
+```
+
+- `MD013: false` — disables line length globally (no inline disable/enable comments needed)
+- `MD041.front_matter_title` — tells markdownlint to recognize `title:` in frontmatter as the first heading, preventing false "first line should be a heading" errors
+
+### Anti-patterns
+
+- **No `<!-- markdownlint-disable MD013 -->` in files** — use `.markdownlint.json` instead. Inline enable/disable pairs re-enable globally disabled rules and cause false positives.
+- **No HTML comments before frontmatter** — anything before `---` on line 1 breaks frontmatter parsing.
+
+## Rules
+
+- No `sources:` key in frontmatter — sources go in the Sources section at end of file
+- Sources section uses reference-style links (`[key]: url` at bottom)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,7 +14,8 @@
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
     "python-dev@qte77-claude-code-utils": true,
-    "commit-helper@qte77-claude-code-utils": true
+    "commit-helper@qte77-claude-code-utils": true,
+    "docs-governance@qte77-claude-code-utils": true
   },
   "permissions": {
     "allow": [

--- a/.github/templates/llms.txt.tpl
+++ b/.github/templates/llms.txt.tpl
@@ -11,14 +11,14 @@
 
 - [Architecture](${BLOB}/docs/architecture.md): Stage graph, contracts, runtime modes, design decisions
 - [Roadmap](${BLOB}/docs/roadmap.md): Versioned milestones (0.1 → 0.6+)
-- [Prototype plan](${BLOB}/docs/prototype-plan.md): Dual-variant E2E prototype (Claude vs Python tools)
+- [Prototype plan](${BLOB}/docs/prototype/plan.md): Dual-variant E2E prototype (Claude vs Python tools)
 
 ## Tool surveys
 
-- [Landscape — Ingest](${BLOB}/docs/landscape-ingest.md): Extraction backends, source connectors, crawling
-- [Landscape — Process](${BLOB}/docs/landscape-process.md): Chunking, NER, RAG indexing, normalization
-- [Landscape — Output](${BLOB}/docs/landscape-output.md): Rendering, office formats, templating, conformance
-- [Landscape — Prior art](${BLOB}/docs/landscape-prior-art.md): E2E pipeline competitors and USP positioning
+- [Landscape — Ingest](${BLOB}/docs/landscape/ingest.md): Extraction backends, source connectors, crawling
+- [Landscape — Process](${BLOB}/docs/landscape/process.md): Chunking, NER, RAG indexing, normalization
+- [Landscape — Output](${BLOB}/docs/landscape/output.md): Rendering, office formats, templating, conformance
+- [Landscape — Prior art](${BLOB}/docs/landscape/prior-art.md): E2E pipeline competitors and USP positioning
 
 ## Governance
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ htmlcov/
 # Project
 release/
 samples/
+outputs/
 
 # Claude Code (machine-local settings only)
 .claude/settings.local.json

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/prototype/results.md` — first-run results of the parallel diff harness on the five locked prototype samples (V2-only; V1 leg blocked pending [#30](https://github.com/qte77/doc-pipeline-engine/issues/30))
+
+### Changed
+
+- Reorganized docs into topical subdirs: `docs/landscape-*.md` → `docs/landscape/*.md` (drops the redundant `landscape-` prefix), `docs/prototype-*.md` → `docs/prototype/*.md`. All cross-references in `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md`, `docs/roadmap.md`, `docs/llms.txt`, `.github/templates/llms.txt.tpl`, and intra-doc links were updated.
+- `.gitignore` — ignore `outputs/` (harness-generated artifacts: per-sample md/docx/pdf and `v2_summary.json`)
+- `Makefile` — drop redundant `@` prefixes and backslash continuations in the `help` recipe (`.SILENT` and `.ONESHELL` already declared); ignore `outputs/**` in `markdownlint`
+
+### Added
+
 - `.github/workflows/generate-sbom.yaml` — calls `qte77/gha-sbom-action@v0.1.0` on weekly cron + push-to-main; outputs SPDX SBOM to `docs/SBOM/`
 - `.github/workflows/write-llms-txt.yaml` — calls `qte77/gha-llms-txt-action@v0.1.0`; auto-generates `docs/llms.txt` from `.github/templates/llms.txt.tpl` whenever docs/src/governance change
 - `.github/templates/llms.txt.tpl` — llms.txt index template covering architecture, roadmap, prototype-plan, four landscape docs, and governance files
@@ -32,13 +42,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Makefile` `install-models` target — `uv run python -m spacy download en_core_web_sm` (needed for V2 NER).
 - `CONTRIBUTING.md` documents the full extras taxonomy with locality flags.
 - Parallel diff harness — `harness.py` with `run_both(sample_path, ...)` returning a `DiffReport` (`LegResult` per variant: contracts, RenderArtifacts, wall_times, eval_report). Extraction is shared (Kreuzberg runs once); only post-extraction stages diverge per leg. CLI: `python -m doc_pipeline_engine.harness <sample> [--output-dir DIR]`. Renders md/docx/pdf to `outputs/<sha256>/v1/` and `outputs/<sha256>/v2/`.
-- `docs/prototype-samples.md` — selection criteria for the five prototype samples (one per use case: bidtender / legal / invoice / spec / diagrams).
-- `docs/prototype-results.md` — placeholder for first-run eval results across the five eval axes (faithfulness, determinism, latency, cost, layout fidelity).
+- `docs/prototype/samples.md` — selection criteria for the five prototype samples (one per use case: bidtender / legal / invoice / spec / diagrams).
+- `docs/prototype/results.md` — placeholder for first-run eval results across the five eval axes (faithfulness, determinism, latency, cost, layout fidelity).
 - `Makefile` targets `test-rerun` (`pytest --lf -x`), `test-fix-snapshots` (`pytest --inline-snapshot=fix`), and `validate` (lint + test + lint-md + lint-links pre-commit gate)
 
 ### Added
 
-- `docs/prototype-plan.md` — dual-variant E2E prototype plan (Claude Code vs landscape tools), Quick-tier-only, with TDD framing per `tdd-core` / `python-dev` plugins and a parallel-diff harness sketch. Roadmap §0.2.0, CONTRIBUTING doc hierarchy, and the four landscape files cross-link to it.
+- `docs/prototype/plan.md` — dual-variant E2E prototype plan (Claude Code vs landscape tools), Quick-tier-only, with TDD framing per `tdd-core` / `python-dev` plugins and a parallel-diff harness sketch. Roadmap §0.2.0, CONTRIBUTING doc hierarchy, and the four landscape files cross-link to it.
 
 ### Changed
 
@@ -46,13 +56,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `docs/landscape-process.md` — process-stage survey (chunking, table/figure extraction, NER, RAG indexing, CanonicalDoc normalization)
-- `docs/landscape-output.md` — output-stage survey (rendering, office formats, templating, FormatConformance validators)
-- `docs/landscape-prior-art.md` — E2E pipeline prior art (arXiv 2025 surveys, OSS systems, commercial IDP) and USP gap analysis
+- `docs/landscape/process.md` — process-stage survey (chunking, table/figure extraction, NER, RAG indexing, CanonicalDoc normalization)
+- `docs/landscape/output.md` — output-stage survey (rendering, office formats, templating, FormatConformance validators)
+- `docs/landscape/prior-art.md` — E2E pipeline prior art (arXiv 2025 surveys, OSS systems, commercial IDP) and USP gap analysis
 
 ### Changed
 
-- `docs/landscape.md` → `docs/landscape-ingest.md`; expanded with source connectors (SharePoint, Confluence, Drive, S3, IMAP, Exchange) and crawling/discovery sections (polyfetch-scrape, trafilatura, httpx, pathlib, watchdog)
+- `docs/landscape.md` → `docs/landscape/ingest.md`; expanded with source connectors (SharePoint, Confluence, Drive, S3, IMAP, Exchange) and crawling/discovery sections (polyfetch-scrape, trafilatura, httpx, pathlib, watchdog)
 - `CONTRIBUTING.md` documentation hierarchy updated to reference the four landscape files
 
 ## [0.1.0] - 2026-04-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `.claude/rules/frontmatter-convention.md` — exact import of `qte77-claude-code-utils/docs-governance/rules/frontmatter-convention.md`; enforces YAML frontmatter (`title`, `purpose`, `created`, `updated`, `validated_links`) on `**/*.md` outside the exempt set
+- `.markdownlint.json` — `MD013: false` (line length) and `MD041.front_matter_title` per the imported rule, so frontmatter `title:` satisfies the first-heading check
+- `.claude/settings.json` `enabledPlugins` — `docs-governance@qte77-claude-code-utils`
+- YAML frontmatter on all `docs/landscape/*.md` and `docs/prototype/*.md` files; body H1 dropped (frontmatter `title` represents it per the rule)
 - `docs/prototype/results.md` — first-run results of the parallel diff harness on the five locked prototype samples (V2-only; V1 leg blocked pending [#30](https://github.com/qte77/doc-pipeline-engine/issues/30))
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,11 +97,11 @@ Authoritative sources — update these, don't duplicate:
 - `README.md` — project overview, quickstart
 - `docs/architecture.md` — design decisions, contracts, runtime modes
 - `docs/roadmap.md` — versioned milestones (0.1 → 0.6+)
-- `docs/landscape-ingest.md` — ingest survey (extraction backends, source connectors, crawling)
-- `docs/landscape-process.md` — process survey (chunking, NER, RAG indexing, normalization)
-- `docs/landscape-output.md` — output survey (rendering, office formats, templating, conformance)
-- `docs/landscape-prior-art.md` — E2E pipeline prior art and USP positioning
-- `docs/prototype-plan.md` — dual-variant E2E prototype plan (Claude Code vs landscape tools)
+- `docs/landscape/ingest.md` — ingest survey (extraction backends, source connectors, crawling)
+- `docs/landscape/process.md` — process survey (chunking, NER, RAG indexing, normalization)
+- `docs/landscape/output.md` — output survey (rendering, office formats, templating, conformance)
+- `docs/landscape/prior-art.md` — E2E pipeline prior art and USP positioning
+- `docs/prototype/plan.md` — dual-variant E2E prototype plan (Claude Code vs landscape tools)
 - `AGENTS.md` — AI agent behavioral rules
 - `CONTRIBUTING.md` — this file
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint:  ## Lint Python with ruff
 lint-md:  ## Lint Markdown (markdownlint, disable MD013)
 	echo "--- lint-md"
 	if command -v markdownlint > /dev/null 2>&1; then
-		markdownlint '**/*.md' --ignore '.venv/**' --ignore 'samples/**' --ignore 'docs/plans/**' --disable MD013
+		markdownlint '**/*.md' --ignore '.venv/**' --ignore 'samples/**' --ignore 'docs/plans/**' --ignore 'outputs/**' --disable MD013
 	else
 		echo "markdownlint not installed — run: npm install -g markdownlint-cli"
 	fi
@@ -76,17 +76,17 @@ clean:  ## Remove caches
 
 
 help:  ## Show available recipes
-	@echo "Usage: make [recipe] [VERBOSE=1]"
-	@echo ""
-	@awk '/^# MARK:/ { \
-		section = substr($$0, index($$0, ":")+2); \
-		printf "\n\033[1m%s\033[0m\n", section \
-	} \
-	/^[a-zA-Z0-9_-]+:.*?##/ { \
-		helpMessage = match($$0, /## (.*)/); \
-		if (helpMessage) { \
-			recipe = $$1; \
-			sub(/:/, "", recipe); \
-			printf "  \033[36m%-22s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH) \
-		} \
+	echo "Usage: make [recipe] [VERBOSE=1]"
+	echo ""
+	awk '/^# MARK:/ {
+		section = substr($$0, index($$0, ":")+2)
+		printf "\n\033[1m%s\033[0m\n", section
+	}
+	/^[a-zA-Z0-9_-]+:.*?##/ {
+		helpMessage = match($$0, /## (.*)/)
+		if (helpMessage) {
+			recipe = $$1
+			sub(/:/, "", recipe)
+			printf "  \033[36m%-22s\033[0m %s\n", recipe, substr($$0, RSTART + 3, RLENGTH)
+		}
 	}' $(MAKEFILE_LIST)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ make test-contracts # schema round-trip tests
 
 - [Architecture](docs/architecture.md) — stage graph, runner vs stream, package layout
 - [Roadmap](docs/roadmap.md) — milestones with reasoning and implementation notes
-- Landscape — pipeline tool surveys: [ingest](docs/landscape-ingest.md), [process](docs/landscape-process.md), [output](docs/landscape-output.md), [prior art](docs/landscape-prior-art.md)
+- Landscape — pipeline tool surveys: [ingest](docs/landscape/ingest.md), [process](docs/landscape/process.md), [output](docs/landscape/output.md), [prior art](docs/landscape/prior-art.md)
 - [Scraping Landscape](https://github.com/qte77/polyfetch-scrape/blob/main/docs/scraping-landscape.md) — web scraping survey (moved to `polyfetch-scrape`)
 - [Changelog](CHANGELOG.md) — release history ([semver](https://semver.org/))

--- a/docs/landscape/ingest.md
+++ b/docs/landscape/ingest.md
@@ -1,6 +1,6 @@
 # Ingest Landscape
 
-Survey of candidates for the **ingest** stage — extraction backends, source connectors, and crawling/discovery providers. Companion files: [landscape-process.md](landscape-process.md), [landscape-output.md](landscape-output.md), [landscape-prior-art.md](landscape-prior-art.md).
+Survey of candidates for the **ingest** stage — extraction backends, source connectors, and crawling/discovery providers. Companion files: [process.md](process.md), [output.md](output.md), [prior-art.md](prior-art.md).
 
 ## Selection criteria
 
@@ -8,7 +8,7 @@ Survey of candidates for the **ingest** stage — extraction backends, source co
 2. **Format coverage / source coverage** — what the tool actually reaches.
 3. **Runtime footprint** — Python-native preferred; JVM/heavy native deps must justify themselves.
 4. **Auth/credential model** — for source connectors, must support OAuth 2.0 / service-account flows.
-5. **Data-locality fit** — note cloud-only paths; relevant to [§0.5.0](roadmap.md#050--domain-packs) `local-only` / `claude-api-extracted-only` / `cloud-redacted` policies.
+5. **Data-locality fit** — note cloud-only paths; relevant to [§0.5.0](../roadmap.md#050--domain-packs) `local-only` / `claude-api-extracted-only` / `cloud-redacted` policies.
 6. **Maintenance signal** — active releases, non-trivial user base.
 
 ## 1. Extraction backends
@@ -28,7 +28,7 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 
 ### Notes
 
-**docling vs Kreuzberg** — not redundant. docling is the layout-accurate path for PDFs that feed `CanonicalDoc`; Kreuzberg is the pragmatic catch-all for the formats docling doesn't handle well (email, xlsx, legacy Office). Run them side by side in [§0.4.0](roadmap.md#040--adapters) cross-validation.
+**docling vs Kreuzberg** — not redundant. docling is the layout-accurate path for PDFs that feed `CanonicalDoc`; Kreuzberg is the pragmatic catch-all for the formats docling doesn't handle well (email, xlsx, legacy Office). Run them side by side in [§0.4.0](../roadmap.md#040--adapters) cross-validation.
 
 **Tesseract positioning** — don't expose as its own adapter. It's a dependency of the Python wrappers; surfacing it separately would duplicate configuration surface for no gain.
 
@@ -54,7 +54,7 @@ Wired behind a `SourceConnector` interface. Emit file lists / blob handles consu
 
 **msgraph-sdk vs O365** — prefer `msgraph-sdk` as primary; it is the officially maintained Microsoft library and maps 1:1 to Graph API docs. O365 stays as an optional shim.
 
-**Data-locality flagging** — every cloud-source connector must declare `data_locality: cloud` so the [§0.5.0](roadmap.md#050--domain-packs) policy layer can refuse to load it under a `local-only` profile. On-prem variants (EWS, Confluence Server, S3-compatible MinIO) are local-friendly.
+**Data-locality flagging** — every cloud-source connector must declare `data_locality: cloud` so the [§0.5.0](../roadmap.md#050--domain-packs) policy layer can refuse to load it under a `local-only` profile. On-prem variants (EWS, Confluence Server, S3-compatible MinIO) are local-friendly.
 
 **boto3 endpoint override** — pass `endpoint_url` to reach MinIO, Backblaze B2, or other S3-compatible stores. No fork required.
 
@@ -84,16 +84,16 @@ Produce the file list that becomes `DiscoveryManifest` (`version`, `source`, `di
 ## See also
 
 - [ai-agents-research / CC-web-scraping-plugins-analysis.md](https://github.com/qte77/ai-agents-research/blob/main/docs/cc-native/plugins-ecosystem/CC-web-scraping-plugins-analysis.md) — Claude Code plugins for web scraping, at the orchestration layer above the connectors and crawlers surveyed here.
-- [prototype-plan.md](prototype-plan.md) — how the candidates surveyed here get exercised in the v1 dual-variant prototype.
+- [../prototype/plan.md](../prototype/plan.md) — how the candidates surveyed here get exercised in the v1 dual-variant prototype.
 
 ## Open questions
 
 - Should `DiscoveryManifest.source` be an enum (cloud-source ID) or a free string?
 - MS Graph throttling (429 / `Retry-After`) — does the connector layer own retry, or does polyfetch-scrape's fetch layer absorb it?
-- Adapter registry policy across extractors: first-match, ensemble, or declared per-domain? → revisit during [§0.5.0 — Domain packs](roadmap.md#050--domain-packs).
+- Adapter registry policy across extractors: first-match, ensemble, or declared per-domain? → revisit during [§0.5.0 — Domain packs](../roadmap.md#050--domain-packs).
 - Minimum cross-validation set: which adapters must agree on which sample categories to call extraction "verified"?
-- Do we need handwriting OCR in scope for [§0.4.0](roadmap.md#040--adapters), or defer with GLM-OCR? → see AGENT_REQUESTS.md if raised.
-- watchdog watch-mode: in-scope for the [§0.5.0](roadmap.md#050--domain-packs) streaming milestone, or defer to a separate `ingest-streaming` extra?
+- Do we need handwriting OCR in scope for [§0.4.0](../roadmap.md#040--adapters), or defer with GLM-OCR? → see AGENT_REQUESTS.md if raised.
+- watchdog watch-mode: in-scope for the [§0.5.0](../roadmap.md#050--domain-packs) streaming milestone, or defer to a separate `ingest-streaming` extra?
 
 ## References
 

--- a/docs/landscape/ingest.md
+++ b/docs/landscape/ingest.md
@@ -108,7 +108,7 @@ Produce the file list that becomes `DiscoveryManifest` (`version`, `source`, `di
 
 - docling: <https://github.com/docling-project/docling>
 - Kreuzberg: <https://github.com/kreuzberg-dev/kreuzberg>
-- GLM-OCR: <https://github.com/THUDM/GLM-4>
+- GLM-OCR: <https://github.com/zai-org/GLM-4>
 - PaddleOCR-VL: <https://github.com/PaddlePaddle/PaddleOCR>
 - Tesseract: <https://github.com/tesseract-ocr/tesseract>
 - PyMuPDF: <https://github.com/pymupdf/PyMuPDF>

--- a/docs/landscape/ingest.md
+++ b/docs/landscape/ingest.md
@@ -1,4 +1,11 @@
-# Ingest Landscape
+---
+title: Ingest Landscape
+purpose: Survey of extraction backends, source connectors, and crawling/discovery providers for the ingest stage
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: landscape
+---
 
 Survey of candidates for the **ingest** stage — extraction backends, source connectors, and crawling/discovery providers. Companion files: [process.md](process.md), [output.md](output.md), [prior-art.md](prior-art.md).
 

--- a/docs/landscape/output.md
+++ b/docs/landscape/output.md
@@ -1,4 +1,11 @@
-# Output Landscape
+---
+title: Output Landscape
+purpose: Survey of rendering, office formats, templating, and conformance validators for the output stage
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: landscape
+---
 
 Survey of candidates for the **output** stage — rendering, office formats, templating, and `OutputFormat` / `FormatConformance` validators. Companion files: [ingest.md](ingest.md), [process.md](process.md), [prior-art.md](prior-art.md).
 

--- a/docs/landscape/output.md
+++ b/docs/landscape/output.md
@@ -1,8 +1,8 @@
 # Output Landscape
 
-Survey of candidates for the **output** stage — rendering, office formats, templating, and `OutputFormat` / `FormatConformance` validators. Companion files: [landscape-ingest.md](landscape-ingest.md), [landscape-process.md](landscape-process.md), [landscape-prior-art.md](landscape-prior-art.md).
+Survey of candidates for the **output** stage — rendering, office formats, templating, and `OutputFormat` / `FormatConformance` validators. Companion files: [ingest.md](ingest.md), [process.md](process.md), [prior-art.md](prior-art.md).
 
-Output emits documents validating against `OutputFormat` (`id`, `version`, `tier`) and `FormatConformance` (`output_format_id`, `conformant`). Tiers from [architecture.md](architecture.md):
+Output emits documents validating against `OutputFormat` (`id`, `version`, `tier`) and `FormatConformance` (`output_format_id`, `conformant`). Tiers from [architecture.md](../architecture.md):
 
 - **Quick** — 1-page Markdown summary
 - **Comprehensive** — IMRaD / tech-spec; full canonical tree + tables/figures/citations
@@ -81,7 +81,7 @@ Backs the `FormatConformance` contract. Practical pattern: rely on writer librar
 ## See also
 
 - [ai-agents-research / CC-office-document-skills.md](https://github.com/qte77/ai-agents-research/blob/main/docs/cc-native/plugins-ecosystem/CC-office-document-skills.md) — how Claude Code itself handles office documents at the orchestration layer (Anthropic's `/v1/skills` API for docx/xlsx/pptx/pdf). Complementary view: this file covers the engine-layer Python libraries; the linked file covers the CC integration layer above them.
-- [prototype-plan.md](prototype-plan.md) — how the rendering and office-format candidates surveyed here get exercised in the v1 dual-variant prototype.
+- [../prototype/plan.md](../prototype/plan.md) — how the rendering and office-format candidates surveyed here get exercised in the v1 dual-variant prototype.
 
 ## Open questions
 

--- a/docs/landscape/prior-art.md
+++ b/docs/landscape/prior-art.md
@@ -52,7 +52,7 @@ This file informs USP positioning. It is *not* a buyer's guide.
 Listed for architectural inspiration; not under evaluation as embeddable deps.
 
 - **ABBYY**, **Hyperscience**, **Rossum**, **Instabase** — full-stack IDP suites with proprietary classification and HITL review.
-- **Azure AI Document Intelligence** ([docs](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/)) — pre-built + custom models; closest cloud equivalent to our extraction tier.
+- **Azure AI Document Intelligence** ([docs](https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/?view=doc-intel-4.0.0)) — pre-built + custom models; closest cloud equivalent to our extraction tier.
 - **AWS Textract / Bedrock Data Automation** — see GenAI IDP Accelerator above.
 - **Google Document AI Workbench** ([docs](https://cloud.google.com/document-ai)) — managed extraction + custom processors.
 

--- a/docs/landscape/prior-art.md
+++ b/docs/landscape/prior-art.md
@@ -1,4 +1,11 @@
-# Prior Art Landscape
+---
+title: Prior Art Landscape
+purpose: E2E document pipeline prior art — academic surveys, OSS systems, commercial IDP, reference architectures
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: landscape
+---
 
 End-to-end (E2E) document pipelines for business / enterprise — academic surveys, OSS systems, commercial IDP, and reference architectures. Companion files: [ingest.md](ingest.md), [process.md](process.md), [output.md](output.md).
 

--- a/docs/landscape/prior-art.md
+++ b/docs/landscape/prior-art.md
@@ -1,6 +1,6 @@
 # Prior Art Landscape
 
-End-to-end (E2E) document pipelines for business / enterprise — academic surveys, OSS systems, commercial IDP, and reference architectures. Companion files: [landscape-ingest.md](landscape-ingest.md), [landscape-process.md](landscape-process.md), [landscape-output.md](landscape-output.md).
+End-to-end (E2E) document pipelines for business / enterprise — academic surveys, OSS systems, commercial IDP, and reference architectures. Companion files: [ingest.md](ingest.md), [process.md](process.md), [output.md](output.md).
 
 This file informs USP positioning. It is *not* a buyer's guide.
 
@@ -16,27 +16,27 @@ This file informs USP positioning. It is *not* a buyer's guide.
 | Paper | What it covers | Relevance |
 | --- | --- | --- |
 | **Agentic RAG: A Survey** ([arXiv:2501.09136](https://arxiv.org/abs/2501.09136)) | Taxonomy of agentic RAG architectures — agent cardinality, control structure, autonomy, knowledge representation. Names LlamaIndex Agentic Document Workflows as E2E reference. | Maps cleanly to our P1–P4 orchestration patterns; useful taxonomy reference. |
-| **RAG: Comprehensive Survey** ([arXiv:2506.00054](https://arxiv.org/abs/2506.00054)) | Adaptive / multi-source / query-refinement / hybrid retrieval families and their trade-offs. | Informs [§0.5.0](roadmap.md#050--domain-packs) RAG indexing choices in [landscape-process.md](landscape-process.md). |
+| **RAG: Comprehensive Survey** ([arXiv:2506.00054](https://arxiv.org/abs/2506.00054)) | Adaptive / multi-source / query-refinement / hybrid retrieval families and their trade-offs. | Informs [§0.5.0](../roadmap.md#050--domain-packs) RAG indexing choices in [process.md](process.md). |
 | **Systematic Review of RAG Systems** ([arXiv:2507.18910](https://arxiv.org/abs/2507.18910)) | Multi-library systematic review (ACL, IEEE, ACM, Scholar) through mid-2025. | Coverage map for gaps (eval, governance). |
 | **Retrieval And Structuring (RAS)** ([arXiv:2509.10697](https://arxiv.org/abs/2509.10697)) | Argues unstructured-passage RAG is fundamentally limited; integrate structured knowledge (taxonomies, hierarchies, KGs). | Validates our `CanonicalDoc.root` tree (structured, not flat passages). |
 | **HetaRAG** ([arXiv:2509.21336](https://arxiv.org/abs/2509.21336)) | Hybrid retrieval across vector + KG + full-text + structured DBs; multimodal (text/diagrams/tables/math). | Reference architecture for cross-store retrieval if `CanonicalDoc` consumers fan out. |
 | **AccurateRAG** ([arXiv:2510.02243](https://arxiv.org/abs/2510.02243)) | Local-environment RAG QA framework; PDF-to-text, eval, fine-tuning. | Closest single-paper analog to our "data-locality first" stance. |
 | **Modular-RAG taxonomy** ([arXiv:2506.10408](https://arxiv.org/abs/2506.10408)) | Compartmentalises tasks into orchestrated modules (query reformulation, retrieval, ranking, synthesis). | Same modular philosophy as our stage-graph / contracts split. |
-| **Engineering the RAG Stack** ([arXiv:2601.05264](https://arxiv.org/html/2601.05264v1)) | Architecture + trust-framework review across retrieval / fusion / modality / trust / adaptivity. | Useful checklist for [§0.6.0](roadmap.md#060--eval) eval. |
+| **Engineering the RAG Stack** ([arXiv:2601.05264](https://arxiv.org/html/2601.05264v1)) | Architecture + trust-framework review across retrieval / fusion / modality / trust / adaptivity. | Useful checklist for [§0.6.0](../roadmap.md#060--eval) eval. |
 
 ## 2. OSS E2E systems
 
 | System | License | E2E scope | Position |
 | --- | --- | --- | --- |
 | **SciPhi-AI / R2R** ([repo](https://github.com/SciPhi-AI/R2R)) | Apache-2.0 | Ingest (PDF/DOCX/MD/MP3/PNG…), chunk, embed, KG extraction, hybrid search, agentic RAG, REST API | **Closest competitor** by feature surface. Difference: R2R is a deployed *service* (REST + Postgres + Docker compose); we are an *embeddable engine* with JSON contracts. |
-| **Unstructured.io** ([repo](https://github.com/Unstructured-IO/unstructured)) | Apache-2.0 (OSS core) + commercial API | Ingest + element-typed extraction + chunking; downstream RAG via partner libs | **Adjacent** — already a candidate processor (see [landscape-process.md](landscape-process.md)). Scope is ingest+extract; we cover all five stages with strict contracts. |
+| **Unstructured.io** ([repo](https://github.com/Unstructured-IO/unstructured)) | Apache-2.0 (OSS core) + commercial API | Ingest + element-typed extraction + chunking; downstream RAG via partner libs | **Adjacent** — already a candidate processor (see [process.md](process.md)). Scope is ingest+extract; we cover all five stages with strict contracts. |
 | **LlamaIndex + LlamaParse + Agentic Document Workflows** ([LlamaIndex](https://github.com/run-llama/llama_index)) | MIT (LlamaIndex), commercial (LlamaParse) | Parse → index → agentic workflow over docs | **Inspiration, not competitor** — we *use* LlamaIndex as a candidate framework; ADW is one possible orchestration pattern over our stages. |
 | **Haystack (deepset)** ([repo](https://github.com/deepset-ai/haystack)) | Apache-2.0 | Pipeline DAG over retriever / reader / generator nodes | **Alternative framework** — graph-based pipeline; heavier than needed for embedded use. |
 | **Docling** ([repo](https://github.com/docling-project/docling)) | MIT | Layout-aware extraction → DoclingDocument | **Already wired** as a primary extraction adapter. |
 | **AWS GenAI IDP Accelerator** ([repo](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws)) | Apache-2.0 | OCR → Bedrock classify → extract → assess → validate → summarize; SAML/OIDC SSO; private VPC; multi-model | **Vendor-locked competitor** — covers same E2E shape, but tied to AWS Bedrock + CloudFormation/CDK/Terraform. We are cloud-agnostic and embeddable. |
 | **AWS Sample IDP Pipeline (multimodal)** ([repo](https://github.com/aws-samples/sample-aws-idp-pipeline)) | Apache-2.0 | Multimodal (PDF/video/audio/image), hybrid search + KG, conversational UI | Reference architecture; explicitly not for production. |
 | **AWS aws-ai-intelligent-document-processing** ([repo](https://github.com/aws-samples/aws-ai-intelligent-document-processing)) | Apache-2.0 | Workshop materials + agentic IDP (Analyzer/Matcher/Extractor/Validator/Troubleshooter) | Reference patterns for agent role decomposition. |
-| **Document Processing for Regulated Industries** ([repo](https://github.com/aws-samples/document-processing-pipeline-for-regulated-industries)) | Apache-2.0 | Image/PDF processing with lineage and pipeline-ops metadata | Lineage pattern reference for [§0.5.0](roadmap.md#050--domain-packs) audit / `local-only` profile. |
+| **Document Processing for Regulated Industries** ([repo](https://github.com/aws-samples/document-processing-pipeline-for-regulated-industries)) | Apache-2.0 | Image/PDF processing with lineage and pipeline-ops metadata | Lineage pattern reference for [§0.5.0](../roadmap.md#050--domain-packs) audit / `local-only` profile. |
 | **thetanishqrathore / IDP** ([repo](https://github.com/thetanishqrathore/IDP)) | Apache-2.0 | RAG-focused: hybrid search (vector + BM25 RRF), context-aware chunking, FastAPI + Qdrant | Solo-maintained; useful as a chunking-strategy reference. |
 | **Awesome Document Understanding** ([repo](https://github.com/tstanislawek/awesome-document-understanding)) | CC-BY (typical for awesome-lists) | Curated index of DU / IDP / RPA resources | Discovery aid for further candidates. |
 
@@ -65,8 +65,8 @@ What competitors *do not* offer that this project does:
 1. **Embeddable engine, not a service.** R2R, AWS IDP, Azure DI, Document AI are services. We ship as a Python library with a CLI; orchestrators (polyforge, office-polyforge, Claude Code plugins) embed us — there is no server to run.
 2. **Contracts as the public API.** Every stage validates against a JSON schema. The data plane is orchestration-agnostic — any system that can produce/consume the schemas can participate.
 3. **Strict license isolation.** Apache-2.0 default; AGPL (PyMuPDF) and JVM (Tika, veraPDF) only as opt-in extras. R2R, Unstructured, and the AWS samples are mostly Apache-2.0 too, but none of them publish a license-isolation policy as a first-class architectural commitment.
-4. **Data-locality policies as a contract dimension.** [§0.5.0](roadmap.md#050--domain-packs) will declare `local-only` / `claude-api-extracted-only` / `cloud-redacted` profiles that gate which adapters can load. None of the surveyed systems express this as a runtime policy — they assume cloud or assume local, without an enforced switch.
-5. **Domain packs.** [§0.5.0](roadmap.md#050--domain-packs) plans `mech-elec-cert` and `med-research-patents` packs (prompts, thresholds, formats). Reduces the configuration surface for regulated industries.
+4. **Data-locality policies as a contract dimension.** [§0.5.0](../roadmap.md#050--domain-packs) will declare `local-only` / `claude-api-extracted-only` / `cloud-redacted` profiles that gate which adapters can load. None of the surveyed systems express this as a runtime policy — they assume cloud or assume local, without an enforced switch.
+5. **Domain packs.** [§0.5.0](../roadmap.md#050--domain-packs) plans `mech-elec-cert` and `med-research-patents` packs (prompts, thresholds, formats). Reduces the configuration surface for regulated industries.
 6. **Two-surface split.** Heavy data plane (Python: extract, validate, render) is decoupled from the optional control plane (skills, agents, hooks). The control plane is replaceable; the data plane is not. Most competitors couple the two.
 7. **Output-format conformance contract.** `OutputFormat` + `FormatConformance` formalise what "valid output" means per tier. Most pipelines treat output as best-effort rendering; we treat it as a validated contract.
 
@@ -79,10 +79,10 @@ What competitors *do* better (areas to learn from):
 
 ## See also
 
-- [prototype-plan.md](prototype-plan.md) — the v1 dual-variant E2E prototype that operationalizes the gap analysis in this file (Claude Code vs landscape tools, side-by-side eval).
+- [../prototype/plan.md](../prototype/plan.md) — the v1 dual-variant E2E prototype that operationalizes the gap analysis in this file (Claude Code vs landscape tools, side-by-side eval).
 
 ## Open questions
 
 - Should we publish a reference deployment (Docker compose) modelled on R2R, or hold the line as a pure library? Trade-off: easier evaluation vs. scope creep into ops.
-- Is the `awesome-document-understanding` list worth mining for [§0.4.0](roadmap.md#040--adapters) cross-validation samples?
-- Does the AccurateRAG paper's local-environment fine-tuning loop belong in [§0.6.0](roadmap.md#060--eval) eval or as a separate domain-pack workflow?
+- Is the `awesome-document-understanding` list worth mining for [§0.4.0](../roadmap.md#040--adapters) cross-validation samples?
+- Does the AccurateRAG paper's local-environment fine-tuning loop belong in [§0.6.0](../roadmap.md#060--eval) eval or as a separate domain-pack workflow?

--- a/docs/landscape/process.md
+++ b/docs/landscape/process.md
@@ -120,8 +120,8 @@ Three load-bearing claims a `CanonicalDoc` makes that downstream stages rely on:
 - spaCy: <https://github.com/explosion/spaCy>
 - GLiNER: <https://github.com/urchade/GLiNER>
 - Flair: <https://github.com/flairNLP/flair>
-- outlines: <https://github.com/outlines-dev/outlines>
-- instructor: <https://github.com/jxnl/instructor>
+- outlines: <https://github.com/dottxt-ai/outlines>
+- instructor: <https://github.com/567-labs/instructor>
 
 ### RAG indexing
 

--- a/docs/landscape/process.md
+++ b/docs/landscape/process.md
@@ -1,14 +1,14 @@
 # Process Landscape
 
-Survey of candidates for the **process** stage — chunking, supplemental table/figure extraction, NER, RAG indexing, and normalization to `CanonicalDoc` (`ExtractionBundle → CanonicalDoc`, [roadmap [§0.5.0](roadmap.md#050--domain-packs).0](roadmap.md#050--domain-packs)). Companion files: [landscape-ingest.md](landscape-ingest.md), [landscape-output.md](landscape-output.md), [landscape-prior-art.md](landscape-prior-art.md).
+Survey of candidates for the **process** stage — chunking, supplemental table/figure extraction, NER, RAG indexing, and normalization to `CanonicalDoc` (`ExtractionBundle → CanonicalDoc`, [roadmap [§0.5.0](../roadmap.md#050--domain-packs).0](../roadmap.md#050--domain-packs)). Companion files: [ingest.md](ingest.md), [output.md](output.md), [prior-art.md](prior-art.md).
 
-`CanonicalDoc` fields: `version`, `source_sha256`, `built_at`, `input_format`, `root` (normalized tree), `tier_summary` (Quick vs Comprehensive — see [architecture.md](architecture.md)). "Canonical" means a normalized tree rooted at `root` carrying tier-aware summary.
+`CanonicalDoc` fields: `version`, `source_sha256`, `built_at`, `input_format`, `root` (normalized tree), `tier_summary` (Quick vs Comprehensive — see [architecture.md](../architecture.md)). "Canonical" means a normalized tree rooted at `root` carrying tier-aware summary.
 
 ## Selection criteria
 
 1. **License compatibility** — Apache-2.0 / MIT preferred; AGPL/GPL opt-in only.
 2. **Runtime footprint** — Python-native preferred; model downloads and GPU requirements declared.
-3. **Data-locality fit** — local-only vs cloud-required; critical for [§0.5.0](roadmap.md#050--domain-packs) policy enforcement.
+3. **Data-locality fit** — local-only vs cloud-required; critical for [§0.5.0](../roadmap.md#050--domain-packs) policy enforcement.
 4. **Format coverage / domain fit** — chunkers, NER models.
 5. **Maintenance signal** — active releases, non-trivial user base.
 
@@ -47,7 +47,7 @@ When extraction backends (docling, Kreuzberg) miss or mangle tables/figures.
 | **outlines** | Constrained LLM decoding for structured NER | Apache-2.0 | Python + torch + local LLM | local (with local model) | **Candidate (local-LLM)** — pairs with Ollama/vLLM; no cloud calls. |
 | **instructor** | Structured output via LLM function-calling | MIT | Python; OpenAI-compatible API | **cloud by default** | **Opt-in only** — violates `local-only` policy unless pointed at local vLLM. Gate behind `[ner-llm]` and require explicit endpoint config. |
 
-**Notes** — Data-locality is the critical axis. spaCy is the safe default. instructor/outlines are the precision ceiling; both require explicit opt-in. Cloud NER calls must be refused under [§0.5.0](roadmap.md#050--domain-packs) `local-only` profile.
+**Notes** — Data-locality is the critical axis. spaCy is the safe default. instructor/outlines are the precision ceiling; both require explicit opt-in. Cloud NER calls must be refused under [§0.5.0](../roadmap.md#050--domain-packs) `local-only` profile.
 
 ## 4. RAG indexing
 
@@ -83,7 +83,7 @@ Three load-bearing claims a `CanonicalDoc` makes that downstream stages rely on:
 
 ## See also
 
-- [prototype-plan.md](prototype-plan.md) — how the chunking, NER, and normalization candidates surveyed here get exercised in the v1 dual-variant prototype.
+- [../prototype/plan.md](../prototype/plan.md) — how the chunking, NER, and normalization candidates surveyed here get exercised in the v1 dual-variant prototype.
 
 ## Open questions
 

--- a/docs/landscape/process.md
+++ b/docs/landscape/process.md
@@ -1,4 +1,11 @@
-# Process Landscape
+---
+title: Process Landscape
+purpose: Survey of chunking, table/figure extraction, NER, RAG indexing, and CanonicalDoc normalization for the process stage
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: landscape
+---
 
 Survey of candidates for the **process** stage — chunking, supplemental table/figure extraction, NER, RAG indexing, and normalization to `CanonicalDoc` (`ExtractionBundle → CanonicalDoc`, [roadmap [§0.5.0](../roadmap.md#050--domain-packs).0](../roadmap.md#050--domain-packs)). Companion files: [ingest.md](ingest.md), [output.md](output.md), [prior-art.md](prior-art.md).
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,14 +11,14 @@
 
 - [Architecture](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/architecture.md): Stage graph, contracts, runtime modes, design decisions
 - [Roadmap](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/roadmap.md): Versioned milestones (0.1 → 0.6+)
-- [Prototype plan](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/prototype-plan.md): Dual-variant E2E prototype (Claude vs Python tools)
+- [Prototype plan](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/prototype/plan.md): Dual-variant E2E prototype (Claude vs Python tools)
 
 ## Tool surveys
 
-- [Landscape — Ingest](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-ingest.md): Extraction backends, source connectors, crawling
-- [Landscape — Process](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-process.md): Chunking, NER, RAG indexing, normalization
-- [Landscape — Output](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-output.md): Rendering, office formats, templating, conformance
-- [Landscape — Prior art](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape-prior-art.md): E2E pipeline competitors and USP positioning
+- [Landscape — Ingest](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/ingest.md): Extraction backends, source connectors, crawling
+- [Landscape — Process](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/process.md): Chunking, NER, RAG indexing, normalization
+- [Landscape — Output](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/output.md): Rendering, office formats, templating, conformance
+- [Landscape — Prior art](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/prior-art.md): E2E pipeline competitors and USP positioning
 
 ## Governance
 

--- a/docs/prototype-results.md
+++ b/docs/prototype-results.md
@@ -6,35 +6,103 @@ samples](prototype-samples.md).
 
 ## Status
 
-**Not yet populated.** The harness lands in PR 6; first real run requires
-`uv sync --extra extract --extra render --extra v1 --extra v2-render`,
-`ANTHROPIC_API_KEY` in env, and the samples downloaded via
-`bash scripts/download-samples.sh --download`.
+**First run completed 2026-04-26 — V2 leg only.** V1 leg blocked pending
+[#30](https://github.com/qte77/doc-pipeline-engine/issues/30): the
+codespace this run executed in had no `ANTHROPIC_API_KEY`. Issue #30
+proposes a Claude Code headless-mode fallback so future runs work on any
+host where `claude` is on `PATH`.
 
 ## Run procedure
 
 ```bash
-# One sample
-uv run python -m doc_pipeline_engine.harness samples/contracts/<file>.pdf \
-  --output-dir outputs/
-
-# Per-sample DiffReport JSON is emitted to stdout; rendered artifacts
-# (md / docx / pdf for both legs) are written under outputs/<sha256>/.
+uv sync --extra extract --extra render --extra v1 --extra v2-render
+bash scripts/download-samples.sh --download
+uv run python -m doc_pipeline_engine.harness <sample> --output-dir outputs/
 ```
 
-## Eval axes (recap)
+The first run used a one-shot V2-only driver (V1 path blocked); future
+runs use the harness CLI directly.
 
-Per [prototype-plan.md → Eval axes](prototype-plan.md#eval-axes):
+## Samples (locked)
 
-1. **Faithfulness** — V1 vs V2 summary contradicts source?
-2. **Determinism** — re-run consistency
-3. **Latency** — wall-clock per leg per stage
-4. **Cost** — Claude API tokens (V1) vs compute seconds (V2)
-5. **Layout fidelity** — table/figure preservation (matters for Comprehensive tier)
+| Use case | Path | sha256 (head) | Bytes |
+| --- | --- | --- | --- |
+| Contract | `samples/contracts/uk-short-form-contract.docx` | `88c177fe3a74` | 292,704 |
+| Legal | `samples/legal/us/us-open-government-act-2007.pdf` | `3af32df1de87` | 136,565 |
+| Invoice | `samples/invoices/nifc-sf1034-invoice.pdf` | `bedf3200fa3c` | 112,565 |
+| Spec | `samples/mech-elec-cert/ti-ne555-datasheet.pdf` | `1df8d26a8bd7` | 2,259,992 |
+| Diagram | `samples/mech-elec-cert/wikimedia-arduino-uno-r3.jpg` | _(extract failed)_ | 244,070 |
 
-## Results — first run
+## V2 axes (first run)
 
-*Pending.*
+| Sample | Extract chars | V2 wall (s) | Claims | Entities | Verdict |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Contract (DOCX) | 219,840 | 0.92 | 1 | 0 | pass |
+| Legal (PDF) | 21,818 | 0.14 | 1 | 0 | pass |
+| Invoice (PDF) | 5,228 | 0.12 | 1 | 0 | pass |
+| Spec (PDF) | 57,174 | 0.39 | 1 | 0 | pass |
+| Diagram (JPG) | — | — | — | — | error |
 
-This file is updated by hand after the first end-to-end run on all
-five prototype samples.
+V2 wall time decomposes as roughly 80–95 % extract + render, and < 1 %
+each for normalize/analyze/eval. Per-sample raw JSON in
+`outputs/v2_summary.json`; rendered Markdown / DOCX / PDF in
+`outputs/<sha256>/v2/`.
+
+## Faithfulness gaps and surprises
+
+1. **`claims = 1` across every sample.** `v2_normalize` builds a single
+   leaf containing the whole extracted text, so `v2_analyze`'s
+   heading-walk produces exactly one claim — the first sentence of the
+   document. The "first sentence" heuristic boundary is `.!?`, which:
+   - works for the legal sample (`PUBLIC LAW 110–175—DEC.`) and the
+     invoice (`Standard Form 1034 VOUCHER NO.`),
+   - degenerates on the UK contract DOCX into a ~3.6 KB bullet
+     containing the entire table-of-contents (no `.!?` until well past
+     the ToC),
+   - clips the NE555 datasheet feature list at the first period, losing
+     the body.
+   None of these are schema violations — `AnalysisReport.claims` only
+   requires `minItems=1` — but they show that V2 normalize is the place
+   to add real heading-tree reconstruction (Kreuzberg returns flat text;
+   the structure has to be inferred). Tracked toward §0.5.0.
+
+2. **`entities = 0` everywhere.** Expected: this run used `--extra
+   v2-render` (no spaCy) because the codespace is on Python 3.14 and
+   spaCy lacks 3.14 wheels. `_maybe_extract_entities` returns `[]`
+   silently when spaCy is missing; the report stays schema-valid. To
+   exercise the NER path, switch to a Python 3.13 codespace and `uv
+   sync --extra v2`.
+
+3. **Image extraction blocked.** Kreuzberg's image path requires a
+   Tesseract install with `eng.traineddata`; this codespace has neither.
+   The diagram sample failed at `extract` with
+   `OCRError: Failed to initialize language 'eng'`. Two fixes possible:
+   add a devcontainer post-create step that installs `tesseract-ocr +
+   tesseract-ocr-eng`, or document the requirement in the run procedure.
+   Filed as a follow-up rather than blocking the prototype.
+
+4. **Render is single-bullet Markdown by design.** `v2_render` Jinja
+   template emits `# Quick Summary\n## Key Claims\n- {claim}\n` for
+   each claim. With one claim per doc, the rendered MD/DOCX/PDF are
+   small (legal: 59 chars MD → 6.5 KB PDF). Once V2 normalize starts
+   producing real sections, render will fan out automatically —
+   template doesn't need changes.
+
+5. **Eval is shallow but honest.** `v2_eval` only checks
+   `schema_valid`. Faithfulness, determinism, latency, cost axes are
+   not yet wired into the eval report itself; they live in the diff
+   harness's `axes` dict. With V1 unavailable, the comparative axes
+   (`latency_ratio_v1_over_v2`, `faithfulness_delta`, `cost_tokens`)
+   couldn't be computed this run.
+
+## Open follow-ups (from this run)
+
+- **#30 — Claude Code headless fallback for V1.** Required to A/B at
+  all without a paid API key. _Implementation queued in next session._
+- **Tesseract devcontainer step** — image samples can't extract until
+  this lands; affects the diagram leg of the A/B.
+- **V2 normalize: heading-tree reconstruction** — the single-leaf
+  shortcut produces structurally honest but semantically empty
+  AnalysisReports. Worth landing before §0.5.0 Comprehensive tier.
+- **Re-run on Python 3.13 codespace** for spaCy NER coverage, or wait
+  for spaCy 3.14 wheels.

--- a/docs/prototype-samples.md
+++ b/docs/prototype-samples.md
@@ -18,9 +18,14 @@ bash scripts/download-samples.sh --download
 | Spec / certification | PDF + DOCX | `mech-elec-cert/` | Heading hierarchy + technical terms; multi-format A/B |
 | Diagrams / scanned | image / scanned PDF | `generic/` | Layout-only or image-only; OCR path stress |
 
-## Locking the five filenames
+## Locked filenames (first run, 2026-04-26)
 
-Concrete filenames are confirmed at first harness run. Until then, the
-selection criteria above stand in. After the first run, this file gets
-updated with the exact paths and sha256 of each sample, and the eval
-results land in [prototype-results.md](prototype-results.md).
+| Use case | Path | sha256 (head) |
+| --- | --- | --- |
+| Contract | `samples/contracts/uk-short-form-contract.docx` | `88c177fe3a74` |
+| Legal | `samples/legal/us/us-open-government-act-2007.pdf` | `3af32df1de87` |
+| Invoice | `samples/invoices/nifc-sf1034-invoice.pdf` | `bedf3200fa3c` |
+| Spec | `samples/mech-elec-cert/ti-ne555-datasheet.pdf` | `1df8d26a8bd7` |
+| Diagram | `samples/mech-elec-cert/wikimedia-arduino-uno-r3.jpg` | _(extract failed; see results)_ |
+
+Run findings live in [prototype-results.md](prototype-results.md).

--- a/docs/prototype/plan.md
+++ b/docs/prototype/plan.md
@@ -1,4 +1,11 @@
-# E2E Prototype Plan
+---
+title: E2E Prototype Plan
+purpose: Dual-variant end-to-end prototype walk-through — Claude Code (V1) versus Python tools (V2) on shared samples
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: implementation
+---
 
 First end-to-end walk-through of the [stage graph](../architecture.md#stage-graph) on a single sample, run as **two parallel variants** so we can A/B Claude Code against the surveyed tools.
 

--- a/docs/prototype/plan.md
+++ b/docs/prototype/plan.md
@@ -1,8 +1,8 @@
 # E2E Prototype Plan
 
-First end-to-end walk-through of the [stage graph](architecture.md#stage-graph) on a single sample, run as **two parallel variants** so we can A/B Claude Code against the surveyed tools.
+First end-to-end walk-through of the [stage graph](../architecture.md#stage-graph) on a single sample, run as **two parallel variants** so we can A/B Claude Code against the surveyed tools.
 
-Scope: **Quick tier only** (see [architecture.md → Output tiers](architecture.md#output-tiers)). Comprehensive tier is deferred to [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs); prototyping it now would over-commit before we know which V1 stages already do the job.
+Scope: **Quick tier only** (see [architecture.md → Output tiers](../architecture.md#output-tiers)). Comprehensive tier is deferred to [roadmap §0.5.0 — Domain packs](../roadmap.md#050--domain-packs); prototyping it now would over-commit before we know which V1 stages already do the job.
 
 ## Goal
 
@@ -27,15 +27,15 @@ Anthropic's office-document skills (`anthropics/skills`) are Claude.ai-only — 
 | Stage | How |
 | --- | --- |
 | Discover | `pathlib.rglob()` → `DiscoveryManifest` (shared with V1) |
-| Extract | **docling** (PDF/Office), **Kreuzberg** (long tail) → `ExtractionBundle`. See [landscape-ingest.md](landscape-ingest.md). |
-| Normalize | Thin Python adapter `DoclingDocument → CanonicalDoc` (adds `source_sha256`, `built_at`, runs tier-split). See [landscape-process.md → Normalization to CanonicalDoc](landscape-process.md#5-normalization-to-canonicaldoc). |
-| Analyze | **spaCy** NER over `root` text nodes → `AnalysisReport` (heading walk for key claims; no RAG at Quick tier). See [landscape-process.md → Entity extraction / NER](landscape-process.md#3-entity-extraction--ner). |
-| Render | **Jinja2** template → 1-page Markdown. See [landscape-output.md](landscape-output.md). |
-| Eval | Schema gates + **DeepEval** or **RAGAs** for faithfulness → `EvalReport`. See [roadmap §0.6.0 — Eval](roadmap.md#060--eval). |
+| Extract | **docling** (PDF/Office), **Kreuzberg** (long tail) → `ExtractionBundle`. See [../landscape/ingest.md](../landscape/ingest.md). |
+| Normalize | Thin Python adapter `DoclingDocument → CanonicalDoc` (adds `source_sha256`, `built_at`, runs tier-split). See [../landscape/process.md → Normalization to CanonicalDoc](../landscape/process.md#5-normalization-to-canonicaldoc). |
+| Analyze | **spaCy** NER over `root` text nodes → `AnalysisReport` (heading walk for key claims; no RAG at Quick tier). See [../landscape/process.md → Entity extraction / NER](../landscape/process.md#3-entity-extraction--ner). |
+| Render | **Jinja2** template → 1-page Markdown. See [../landscape/output.md](../landscape/output.md). |
+| Eval | Schema gates + **DeepEval** or **RAGAs** for faithfulness → `EvalReport`. See [roadmap §0.6.0 — Eval](../roadmap.md#060--eval). |
 
 ## Eval axes
 
-Both variants emit valid contracts at every gate (see [architecture.md → Core idea](architecture.md#core-idea)). A small harness (~100 LOC) runs both legs on the same sample and diffs:
+Both variants emit valid contracts at every gate (see [architecture.md → Core idea](../architecture.md#core-idea)). A small harness (~100 LOC) runs both legs on the same sample and diffs:
 
 1. **Faithfulness** — does the summary contradict the source? (RAGAs faithfulness metric + manual spot-check)
 2. **Determinism** — re-run 3× per leg; assert byte equality (V2) or N-of-M consistency (V1)
@@ -45,12 +45,12 @@ Both variants emit valid contracts at every gate (see [architecture.md → Core 
 
 ## TDD framing
 
-Per `tdd-core/testing-tdd` and `python-dev/testing-python` plugins (declared in [`.claude/settings.json`](../.claude/settings.json)):
+Per `tdd-core/testing-tdd` and `python-dev/testing-python` plugins (declared in [`.claude/settings.json`](../../.claude/settings.json)):
 
 - **pytest** for known cases — Arrange-Act-Assert; naming `test_{module}_{component}_{behavior}`
 - **Hypothesis** for property-based assertions on V1's nondeterministic stages — "extracted entities ⊇ {known minimum}", "schema validates", "key claims contain expected substrings"
 - **inline-snapshot** for golden-output regression on V2's deterministic stages
-- Schema gates already TDD'd in [roadmap §0.1.0 — Contracts](roadmap.md#010--contracts) (38 round-trip tests)
+- Schema gates already TDD'd in [roadmap §0.1.0 — Contracts](../roadmap.md#010--contracts) (38 round-trip tests)
 
 | Stage type | Tooling |
 | --- | --- |
@@ -60,23 +60,23 @@ Per `tdd-core/testing-tdd` and `python-dev/testing-python` plugins (declared in 
 
 ## Sequencing
 
-1. **V1 first** — fastest path to any working E2E loop. ~1–2 days. Builds on [roadmap §0.2.0 — Runner](roadmap.md#020--runner).
+1. **V1 first** — fastest path to any working E2E loop. ~1–2 days. Builds on [roadmap §0.2.0 — Runner](../roadmap.md#020--runner).
 2. **V2 normalize + render only**, reusing V1 extraction output. Lets us A/B "Claude extract vs docling extract" cheaply by swapping one stage.
 3. **Full V2** + parallel diff harness. Run the eval matrix.
-4. Decide per stage: keep Claude, swap to tools, or run both as cross-validation (mirrors [roadmap §0.4.0 — Adapters](roadmap.md#040--adapters) cross-validation strategy).
+4. Decide per stage: keep Claude, swap to tools, or run both as cross-validation (mirrors [roadmap §0.4.0 — Adapters](../roadmap.md#040--adapters) cross-validation strategy).
 
 PDF is the cleanest A/B — neither variant shares Office-format deps in extract. Office formats share `python-docx` / `openpyxl` / `python-pptx`, so the V1-vs-V2 signal there is weaker.
 
 ## Out of scope for v1
 
-- Comprehensive tier (full canonical tree, RAG indexing, citations) — [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs)
-- Source connectors beyond local filesystem — [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs)
-- Domain packs — [roadmap §0.5.0 — Domain packs](roadmap.md#050--domain-packs)
-- `OutputFormat` / `FormatConformance` strict validators — [roadmap §0.6.0 — Eval](roadmap.md#060--eval)
+- Comprehensive tier (full canonical tree, RAG indexing, citations) — [roadmap §0.5.0 — Domain packs](../roadmap.md#050--domain-packs)
+- Source connectors beyond local filesystem — [roadmap §0.5.0 — Domain packs](../roadmap.md#050--domain-packs)
+- Domain packs — [roadmap §0.5.0 — Domain packs](../roadmap.md#050--domain-packs)
+- `OutputFormat` / `FormatConformance` strict validators — [roadmap §0.6.0 — Eval](../roadmap.md#060--eval)
 - Multi-sample evaluation — once v1 lands on one sample, expand sample set
 
 ## References
 
-- [Architecture](architecture.md) — stage graph + contracts
-- [Roadmap](roadmap.md) — milestone scope per version
-- [landscape-ingest.md](landscape-ingest.md), [landscape-process.md](landscape-process.md), [landscape-output.md](landscape-output.md), [landscape-prior-art.md](landscape-prior-art.md) — tool surveys feeding this plan
+- [Architecture](../architecture.md) — stage graph + contracts
+- [Roadmap](../roadmap.md) — milestone scope per version
+- [../landscape/ingest.md](../landscape/ingest.md), [../landscape/process.md](../landscape/process.md), [../landscape/output.md](../landscape/output.md), [../landscape/prior-art.md](../landscape/prior-art.md) — tool surveys feeding this plan

--- a/docs/prototype/results.md
+++ b/docs/prototype/results.md
@@ -1,4 +1,11 @@
-# Prototype results
+---
+title: Prototype results
+purpose: Recorded outputs of the parallel diff harness across the five locked prototype samples
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: implementation
+---
 
 Outputs of the [parallel diff harness](plan.md) running both
 V1 (Claude API) and V2 (Python tools) legs on the [prototype

--- a/docs/prototype/results.md
+++ b/docs/prototype/results.md
@@ -1,8 +1,8 @@
 # Prototype results
 
-Outputs of the [parallel diff harness](prototype-plan.md) running both
+Outputs of the [parallel diff harness](plan.md) running both
 V1 (Claude API) and V2 (Python tools) legs on the [prototype
-samples](prototype-samples.md).
+samples](samples.md).
 
 ## Status
 

--- a/docs/prototype/samples.md
+++ b/docs/prototype/samples.md
@@ -1,6 +1,6 @@
 # Prototype sample selection
 
-Five samples drive the v1 [E2E prototype](prototype-plan.md), one per
+Five samples drive the v1 [E2E prototype](plan.md), one per
 use case, covering the file-type spectrum (PDF, DOCX, XLSX, text, image).
 Sample binaries are gitignored; obtain them with:
 
@@ -28,4 +28,4 @@ bash scripts/download-samples.sh --download
 | Spec | `samples/mech-elec-cert/ti-ne555-datasheet.pdf` | `1df8d26a8bd7` |
 | Diagram | `samples/mech-elec-cert/wikimedia-arduino-uno-r3.jpg` | _(extract failed; see results)_ |
 
-Run findings live in [prototype-results.md](prototype-results.md).
+Run findings live in [results.md](results.md).

--- a/docs/prototype/samples.md
+++ b/docs/prototype/samples.md
@@ -1,4 +1,11 @@
-# Prototype sample selection
+---
+title: Prototype sample selection
+purpose: Locks the five concrete samples (one per use case) the v1 prototype runs against
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: implementation
+---
 
 Five samples drive the v1 [E2E prototype](plan.md), one per
 use case, covering the file-type spectrum (PDF, DOCX, XLSX, text, image).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ Schemas define the interface between every pipeline stage. Nothing runs without 
 
 ## 0.2.0 — Runner
 
-Stage chain that passes JSON between stages in-process. Minimum viable pipeline. Prototype walk-through: see [prototype-plan.md](prototype-plan.md).
+Stage chain that passes JSON between stages in-process. Minimum viable pipeline. Prototype walk-through: see [prototype/plan.md](prototype/plan.md).
 
 **Why now**: contracts without a runner are just static files. The runner proves the contracts work as a real data flow.
 


### PR DESCRIPTION
## Summary

Three topical commits:

1. **`a13e787` Prototype first-run results (V2-only) + Makefile cleanup** — runs the diff harness on the five locked samples (V2 leg only; V1 blocked by missing `ANTHROPIC_API_KEY`, follow-up in #30). Adds the actual axes/findings to `docs/prototype/results.md`, locks sample paths in `docs/prototype/samples.md`, ignores `outputs/` in `.gitignore` and markdownlint, and drops redundant `@`/backslash continuations from the `Makefile` `help` recipe.
2. **`39a9cfe` Docs reorg** — moves `docs/landscape-*.md` → `docs/landscape/*.md` and `docs/prototype-*.md` → `docs/prototype/*.md` (drops the now-redundant filename prefix). Updates every cross-reference: CHANGELOG.md, CONTRIBUTING.md, README.md, docs/roadmap.md, docs/llms.txt, the `.github/templates/llms.txt.tpl` template, and intra-doc links.
3. **`05fef2f` Frontmatter governance** — imports `docs-governance/rules/frontmatter-convention.md` (verbatim) from the `qte77-claude-code-utils` marketplace into `.claude/rules/`, enables `docs-governance@qte77-claude-code-utils` in `.claude/settings.json`, adds `.markdownlint.json` (`MD013: false`, `MD041.front_matter_title`) per the rule, and applies YAML frontmatter to all `docs/landscape/*.md` and `docs/prototype/*.md` files. Body H1 is dropped on those files because the rule treats the frontmatter `title` as the H1.

## V2 first-run snapshot

| Sample | Extract chars | V2 wall (s) | Claims | Verdict |
|---|---:|---:|---:|---|
| Contract (DOCX) | 219,840 | 0.92 | 1 | pass |
| Legal (PDF) | 21,818 | 0.14 | 1 | pass |
| Invoice (PDF) | 5,228 | 0.12 | 1 | pass |
| Spec (PDF) | 57,174 | 0.39 | 1 | pass |
| Diagram (JPG) | — | — | — | error (Tesseract `eng` traineddata missing) |

Surprises captured in `docs/prototype/results.md`: V2 normalize collapses every doc into one section → `claims = 1` everywhere; spaCy NER skipped on Python 3.14; image OCR blocked locally.

## Open follow-ups

- #30 — Claude Code headless fallback for V1 (queued for next session, plan-mode).
- Tesseract `eng.traineddata` step in the devcontainer (image samples).
- V2 normalize: real heading-tree reconstruction (currently a single leaf).

## Test plan

- [x] `make lint`
- [x] `make lint-md`
- [x] `make test`
- [ ] `make lint-links` — 5 expected 404s for the new doc paths in `docs/llms.txt`; resolve once merged to main (same race as the gha-llms-txt-action workflow).

Generated with Claude <noreply@anthropic.com>