### PR TITLE
ci: pin CodeQL workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,19 +18,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         languages: python
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
 
     - name: Perform CodeQL Analysis
       id: analyze
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
       with:
         output: sarif-results
 


### PR DESCRIPTION
## Summary

Pins \`actions/checkout@v4\` and the three \`github/codeql-action/*@v4\` refs in \`.github/workflows/codeql.yaml\` to full-length commit SHAs. Repo policy refuses unpinned tag refs, so every CodeQL run on \`main\` and on PRs has been failing at "Set up job":

> The actions actions/checkout@v4 and github/codeql-action/init@v4 are not allowed in qte77/doc-pipeline-engine because all actions must be pinned to a full-length commit SHA.

Pinning matches the pattern already used in \`generate-sbom.yaml\` and \`write-llms-txt.yaml\`.

## Test plan

- [ ] CodeQL workflow on this PR passes "Set up job".
- [ ] Subsequent CodeQL runs on \`main\` pass after merge.

Generated with Claude <noreply@anthropic.com>