### PR TITLE
chore: process.md typo + frontmatter on architecture/roadmap + checkout@v6

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,11 @@
-# Architecture
+---
+title: Architecture
+purpose: Stage graph, contracts, runtime modes, and design decisions for the pipeline engine
+created: 2026-04-23
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: technical
+---
 
 ## Core idea
 

--- a/docs/landscape/process.md
+++ b/docs/landscape/process.md
@@ -7,7 +7,7 @@ validated_links: 2026-04-26
 category: landscape
 ---
 
-Survey of candidates for the **process** stage — chunking, supplemental table/figure extraction, NER, RAG indexing, and normalization to `CanonicalDoc` (`ExtractionBundle → CanonicalDoc`, [roadmap [§0.5.0](../roadmap.md#050--domain-packs).0](../roadmap.md#050--domain-packs)). Companion files: [ingest.md](ingest.md), [output.md](output.md), [prior-art.md](prior-art.md).
+Survey of candidates for the **process** stage — chunking, supplemental table/figure extraction, NER, RAG indexing, and normalization to `CanonicalDoc` (`ExtractionBundle → CanonicalDoc`, [roadmap §0.5.0](../roadmap.md#050--domain-packs)). Companion files: [ingest.md](ingest.md), [output.md](output.md), [prior-art.md](prior-art.md).
 
 `CanonicalDoc` fields: `version`, `source_sha256`, `built_at`, `input_format`, `root` (normalized tree), `tier_summary` (Quick vs Comprehensive — see [architecture.md](../architecture.md)). "Canonical" means a normalized tree rooted at `root` carrying tier-aware summary.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,11 @@
-# Roadmap
+---
+title: Roadmap
+purpose: Versioned milestones (0.1 → 0.6+) with status, scope, and reasoning per release
+created: 2026-04-23
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: requirements
+---
 
 ## 0.1.0 — Contracts
 


### PR DESCRIPTION
Three small topical commits cleaning up loose ends from the prototype/devcontainer rounds.

## Summary

1. **\`docs(landscape)\`** — fix the pre-existing nested-bracket malformation \`[roadmap [§0.5.0](../roadmap.md#…).0](…)\` in \`docs/landscape/process.md\` intro. Rendered as literal text in markdown viewers; collapsed to a single clean reference.
2. **\`docs\`** — add YAML frontmatter to \`docs/architecture.md\` and \`docs/roadmap.md\` per the docs-governance rule imported in #31. Body H1 dropped on each (frontmatter \`title:\` represents it; MD041.front_matter_title is configured). \`docs/llms.txt\` is .txt and outside the rule's \`**/*.md\` scope; left alone (cross-repo enhancement filed as qte77/gha-llms-txt-action#6).
3. **\`ci\`** — bump \`codeql.yaml\`'s \`actions/checkout\` from v4 to v6.0.2 (the SHA already in use by \`generate-sbom.yaml\` and \`write-llms-txt.yaml\`). v6 runs on Node 24, clearing the Node-20 deprecation warning that has been firing on every CodeQL run.

## Test plan

- [x] \`make lint_md\` clean
- [x] \`make lint_links\` 173/173 OK, zero errors
- [ ] CodeQL on this PR passes (and the warning about \`actions/checkout@34e1148\` should be gone for the checkout step; \`advanced-security/dismiss-alerts\` warning persists until upstream releases a Node-24 build).
- [ ] CodeFactor passes.

Generated with Claude <noreply@anthropic.com>