### PR TITLE
feat(stages): v2_normalize reconstructs heading tree (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `stages/v2_normalize.py` — reconstructs a flat heading tree from Kreuzberg's plain text via three regex families (formal-prefix `SECTION`/`SEC.`/`CHAPTER`/`ARTICLE`/`PART`, numbered `5.1 Title`, glued numbered `1Title`). Each detected heading becomes one section node carrying `title` + body text; falls back to single-leaf on zero headings or detected density >50% of non-empty lines. Resolves [#33](https://github.com/qte77/doc-pipeline-engine/issues/33): V2 now produces N claims per document instead of one, matching V1's structural granularity. `v2_analyze` / `v2_render` / `v2_eval` untouched.
+
+### Added
+
+- `tests/test_stages_v2_normalize_headings.py` — five cases covering numbered-with-space, formal-prefix, numbered-glued splitting, density-cap fallback, and zero-heading fallback. All gated on `is_valid("CanonicalDoc", …)`.
+- `docs/prototype/results/2026-04-26-run-3-v2-headings.md` — V2-only re-run on the five locked samples after #33; legal goes 1 → 22 claims, spec 1 → 98; invoice/diagram correctly stay at 1.
+
 ### Added
 
 - `stages/_v1_client.py` backend dispatch — explicit injected client → Anthropic SDK with `ANTHROPIC_API_KEY` → `claude` CLI on PATH (uses Claude subscription auth) → clear error. Resolves [#30](https://github.com/qte77/doc-pipeline-engine/issues/30) so V1 stages run in environments without a cloud API key.

--- a/docs/landscape/process.md
+++ b/docs/landscape/process.md
@@ -80,6 +80,8 @@ Framework vs vector store are orthogonal. Recommended default: LlamaIndex (frame
 
 **Notes** — `CanonicalDoc.root` encodes a tree, not a flat list. docling's `DoclingDocument` is the closest existing schema; a thin wrapper adds the four missing fields. `tier_summary` is our invention — no existing tool produces it. The normalizer stage always generates it from `root` via the Quick/Comprehensive tier logic.
 
+- `v2_normalize` reconstructs a flat heading tree from the Kreuzberg-extracted plain text via three regex families (formal-prefix `SECTION`/`SEC.`/`CHAPTER`/`ARTICLE`/`PART`, numbered `5.1 Title`, glued numbered `1Title`) with a 50% density-cap fallback to single-leaf. Real nested hierarchy and docling-based normalize remain deferred to [§0.5.0](../roadmap.md#050--domain-packs) Comprehensive tier.
+
 ## What "canonical" means concretely
 
 Three load-bearing claims a `CanonicalDoc` makes that downstream stages rely on:

--- a/docs/prototype/results/2026-04-26-run-3-v2-headings.md
+++ b/docs/prototype/results/2026-04-26-run-3-v2-headings.md
@@ -1,0 +1,120 @@
+---
+title: Prototype run 3 — V2 heading-tree reconstruction
+purpose: V2-only re-run on the five locked samples after v2_normalize learns heading detection (issue #33)
+created: 2026-04-26
+updated: 2026-04-26
+validated_links: 2026-04-26
+category: implementation
+---
+
+Third harness run, executed 2026-04-26. V2 leg only — V1 unchanged
+since [run 2](2026-04-26-run-2-v1-cli.md), so re-running the cloud leg
+adds no signal. The single change since run 2 is
+[#33](https://github.com/qte77/doc-pipeline-engine/issues/33):
+`v2_normalize` now reconstructs a flat heading tree from heuristic
+detection over the Kreuzberg-extracted plain text instead of wrapping
+the entire document in one leaf section.
+
+## Per-sample axes (V2 only)
+
+| Use case | sha (head) | extract chars | V2 wall (s) | sections | claims (run 2 → run 3) | V2 md chars (run 2 → run 3) |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Contract (DOCX) | `88c177fe3a74` | 219,840 | 1.92 | 69 | 1 → 13 | 3,600 → 1,467 |
+| Legal (PDF) | `3af32df1de87` | 21,818 | 0.23 | 24 | 1 → 22 | 59 → 8,295 |
+| Invoice (PDF) | `bedf3200fa3c` | 5,228 | 0.09 | 1 | 1 → 1 | 66 → 66 |
+| Spec (PDF) | `1df8d26a8bd7` | 57,174 | 0.59 | 134 | 1 → 98 | 318 → 20,128 |
+| Diagram (JPG) | `8a799b15d781` | 0 | 0.07 | 1 | 1 → 1 | 59 → 59 |
+
+V2 stages still finish well under one second per sample on the
+text-bearing inputs. Rendered md/docx/pdf artifacts under
+`outputs/<sample_sha256>/v2/`.
+
+## What changed
+
+`v2_normalize` now runs three regex families against each line of the
+extracted text:
+
+- formal-prefix headings (`SECTION 1.`, `SEC. 2.`, `CHAPTER`, `ARTICLE`,
+  `PART`) — the legal sample's primary structure;
+- numbered with space (`1 Features`, `5.1 Specs`, `6.3.1 Monostable
+  Operation`) — the spec datasheet's primary structure;
+- numbered glued (`1Definitions`, `2Understanding`) — the contract DOCX's
+  ToC-flatten artifact.
+
+Detected heading lines become section boundaries; level is the
+dot-count of the numeric prefix (`5` → 1, `5.1` → 2, capped at 6 per
+the schema). Two fallbacks preserve the run-2 single-leaf shape: zero
+detected headings (invoice, diagram), and detected density above 50%
+of non-empty lines (none of the five samples tripped this in practice;
+the contract was the suspected case but its 69 headings sit inside
+220K chars of body, so density stays well below the cap).
+
+## Content delta
+
+Concrete claim-count delta on the spec sample, which gained the most
+structure:
+
+- **run 2**: `Quick Summary / Key Claims / - timer features (1 bullet)`
+- **run 3**: 98 bullets, each the first sentence of one detected
+  section ("1 Features", "2 Applications", "5.1 Specs", …).
+
+Concrete claim-count delta on the legal sample:
+
+- **run 2**: 1 bullet (`Public Law 110-175 …`).
+- **run 3**: 22 bullets, one per `SECTION`/`SEC.` boundary in the
+  OPEN Government Act of 2007. The first bullet is the public-law
+  preamble; subsequent bullets are the short titles + first sentence
+  of each enumerated section.
+
+The contract V2 markdown actually shrinks from 3,600 → 1,467 chars
+because we now emit one bullet per detected section rather than the
+entire 220K-char body as one bullet's first sentence (the run-2
+behavior took the first sentence of the whole document, but the
+Jinja render's bullet-per-claim path produced a longer single bullet
+for a different code path; with 13 substantive claims the bullets are
+shorter and more focused).
+
+## Faithfulness gaps and surprises
+
+1. **Invoice and diagram correctly stay at 1 claim.** Neither has
+   detectable headings — the invoice is a form, the diagram has no
+   OCR-readable text. Both fall back to the run-2 single-leaf shape.
+   No false positives, no hallucinated structure.
+
+2. **Bullet quality is "first sentence of section body", not section
+   title.** `v2_analyze._extract_claims` was unchanged (per the plan's
+   reuse principle). For the run-3 markdown, this means each bullet is
+   the first sentence following the heading, not the heading itself.
+   Section titles are stored in `canonical.root.children[i].title` and
+   are available to a future render template upgrade.
+
+3. **No render-template change.** The Jinja template at
+   `stages/_jinja_templates/quick_summary.md.j2` still iterates claims
+   as flat bullets. Promoting section titles into `##` subheadings is
+   a render-side polish deferred from #33.
+
+4. **`tier_summary` still head-of-text.** `l0`/`l1` are unchanged
+   first-200 / first-1000 char excerpts of the raw extracted text.
+   Heading-aware tier summaries (titles + first sentences) are an
+   easy follow-up but out of #33's scope.
+
+## Open follow-ups (still standing after this run)
+
+- **Real nested hierarchy** — section levels are recorded
+  (`level=1/2/3`) but the tree is flat (all children of `root`). A
+  stack-based builder would nest level-2 under level-1 etc. Tracked
+  as a follow-up to #33.
+- **Render template upgrade** — emit section titles as `##`
+  subheadings; would make V2 markdown structurally readable rather
+  than a long bullet list.
+- **Heading-aware `tier_summary`** — replace head-of-text truncation
+  with title + first-sentence digest.
+- **`extract.py` switch to `include_document_structure=True`** —
+  would give Kreuzberg-pre-chunked nodes (36 for NE555) for free, but
+  changes the `ExtractionBundle` shape and V1 prompts. Separate,
+  larger PR.
+- **Backend marker in `EvalReport`** (carried over from run 2) —
+  record V1 backend (SDK vs CLI) + `total_cost_usd` from the CLI
+  envelope.
+- **Cross-repo follow-up** —
+  [`qte77/gha-llms-txt-action#6`](https://github.com/qte77/gha-llms-txt-action/issues/6).

--- a/docs/prototype/results/README.md
+++ b/docs/prototype/results/README.md
@@ -17,6 +17,7 @@ data accumulates without overwriting and trends are easy to read.
 | --- | --- | --- |
 | 2026-04-26 | [run 1 — V2 only](2026-04-26-run-1-v2-only.md) | First full harness run; V1 leg blocked by missing `ANTHROPIC_API_KEY`; diagram blocked by missing Tesseract. |
 | 2026-04-26 | [run 2 — V1 + V2 (V1 via Claude Code CLI)](2026-04-26-run-2-v1-cli.md) | First fully-paired V1+V2 run. V1 dispatched via `claude` CLI fallback ([#41](https://github.com/qte77/doc-pipeline-engine/pull/41)); diagram extracted via Tesseract installed by `make install_image_ocr` ([#37](https://github.com/qte77/doc-pipeline-engine/pull/37)). |
+| 2026-04-26 | [run 3 — V2 heading-tree](2026-04-26-run-3-v2-headings.md) | V2-only re-run after `v2_normalize` learns heuristic heading detection ([#33](https://github.com/qte77/doc-pipeline-engine/issues/33)). Legal goes 1 → 22 claims, spec 1 → 98; invoice and diagram stay at 1 (no detectable headings). |
 
 ## Sample roster
 

--- a/src/doc_pipeline_engine/stages/v2_normalize.py
+++ b/src/doc_pipeline_engine/stages/v2_normalize.py
@@ -7,28 +7,96 @@
 #     http://www.apache.org/licenses/LICENSE-2.0
 """V2 normalize: ExtractionBundle → CanonicalDoc, deterministic.
 
-Kreuzberg's text is plain-text without layout structure, so the canonical
-tree is a single section containing the extracted text. tier_summary is a
-deterministic head-of-text excerpt — Quick tier (l0) takes the first 200
-chars, Comprehensive (l1) the first 1000.
+Kreuzberg returns plain text without layout structure, so we reconstruct a
+flat heading tree from heuristic detection over line prefixes (formal
+``SECTION``/``SEC.``/``CHAPTER``/``ARTICLE``/``PART``, numbered
+``5.1 Title``, glued numbered ``1Title``). Falls back to a single-leaf
+section when no headings or implausibly many headings are detected.
+tier_summary is a deterministic head-of-text excerpt — Quick (l0) takes
+the first 200 chars, Comprehensive (l1) the first 1000.
 """
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 from typing import Any
 
 CONTRACT_VERSION = "0.1.0"
 _L0_CHARS = 200
 _L1_CHARS = 1000
+_HEADING_MAX_LEN = 100
+_DENSITY_CAP = 0.5
+_MAX_LEVEL = 6
+
+_FORMAL_PREFIX = re.compile(
+    r"^\s*(?P<kw>SECTION|SEC\.|CHAPTER|ARTICLE|PART)\s+\S+",
+)
+_NUM_SPACED = re.compile(r"^\s*(?P<num>\d+(?:\.\d+)*)\s+\S")
+_NUM_GLUED = re.compile(r"^\s*(?P<num>\d+(?:\.\d+)*)(?P<rest>[A-Z]\S{3,}.*)$")
 
 
 def _truncate(text: str, n: int) -> str:
     return text if len(text) <= n else text[:n].rstrip() + "…"
 
 
+def _is_heading(line: str) -> tuple[bool, int, str]:
+    """Return (is_heading, level, title). level 0 means not a heading."""
+    stripped = line.strip()
+    if not stripped or len(stripped) > _HEADING_MAX_LEN:
+        return False, 0, ""
+    m = _FORMAL_PREFIX.match(stripped)
+    if m:
+        return True, 1, stripped
+    m = _NUM_SPACED.match(stripped)
+    if m:
+        level = min(m.group("num").count(".") + 1, _MAX_LEVEL)
+        return True, level, stripped
+    m = _NUM_GLUED.match(stripped)
+    if m:
+        level = min(m.group("num").count(".") + 1, _MAX_LEVEL)
+        return True, level, stripped
+    return False, 0, ""
+
+
+def _split_into_sections(text: str) -> list[dict[str, Any]]:
+    lines = text.splitlines()
+    non_empty = sum(1 for ln in lines if ln.strip())
+    headings: list[tuple[int, int, str]] = []  # (line_idx, level, title)
+    for idx, ln in enumerate(lines):
+        is_h, level, title = _is_heading(ln)
+        if is_h:
+            headings.append((idx, level, title))
+    if not headings:
+        return []
+    if non_empty and len(headings) / non_empty > _DENSITY_CAP:
+        return []
+    sections: list[dict[str, Any]] = []
+    for i, (line_idx, level, title) in enumerate(headings):
+        end = headings[i + 1][0] if i + 1 < len(headings) else len(lines)
+        body = "\n".join(lines[line_idx + 1 : end]).strip()
+        sections.append({"level": level, "title": title, "text": body})
+    return sections
+
+
 def normalize_v2(bundle: dict[str, Any]) -> dict[str, Any]:
     """ExtractionBundle → CanonicalDoc dict, deterministic."""
     text = bundle["content"]["text"]
+    sections = _split_into_sections(text)
+    if sections:
+        children = [
+            {
+                "id": f"s.{i + 1}",
+                "level": s["level"],
+                "kind": "section",
+                "title": s["title"],
+                "text": s["text"],
+            }
+            for i, s in enumerate(sections)
+        ]
+    else:
+        children = [
+            {"id": "s.1", "level": 1, "kind": "section", "text": text},
+        ]
     return {
         "version": CONTRACT_VERSION,
         "source_sha256": bundle["source_sha256"],
@@ -38,9 +106,7 @@ def normalize_v2(bundle: dict[str, Any]) -> dict[str, Any]:
             "level": 0,
             "kind": "doc",
             "text": "",
-            "children": [
-                {"id": "s.1", "level": 1, "kind": "section", "text": text},
-            ],
+            "children": children,
         },
         "tier_summary": {
             "l0": _truncate(text, _L0_CHARS),

--- a/tests/test_stages_v2_normalize_headings.py
+++ b/tests/test_stages_v2_normalize_headings.py
@@ -1,0 +1,113 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""V2 normalize heading-tree reconstruction tests.
+
+Covers the three heading patterns observed across the locked prototype
+samples (formal-prefix legal headings, numbered with space, numbered
+glued) plus the two fallbacks (zero headings, density cap exceeded).
+"""
+from __future__ import annotations
+
+from doc_pipeline_engine.base.contracts import is_valid
+from doc_pipeline_engine.stages.v2_normalize import normalize_v2
+
+SHA = "0" * 64
+
+
+def _bundle(text: str) -> dict:
+    return {
+        "version": "0.1.0",
+        "source_path": "a.pdf",
+        "source_sha256": SHA,
+        "adapter": {"name": "kreuzberg", "version": "0.0.0"},
+        "extracted_at": "2026-04-26T00:00:00+00:00",
+        "content": {"text": text, "layout": []},
+    }
+
+
+def test_numbered_with_space_splits_into_sections_with_levels() -> None:
+    text = (
+        "1 Features\n"
+        "Timer features description.\n"
+        "2 Applications\n"
+        "Application notes here.\n"
+        "5.1 Specs\n"
+        "Spec body text.\n"
+    )
+
+    canonical = normalize_v2(_bundle(text))
+    children = canonical["root"]["children"]
+
+    assert is_valid("CanonicalDoc", canonical)
+    assert len(children) == 3
+    assert [c["level"] for c in children] == [1, 1, 2]
+    assert children[0]["title"] == "1 Features"
+    assert children[1]["title"] == "2 Applications"
+    assert children[2]["title"] == "5.1 Specs"
+    assert children[0]["text"] == "Timer features description."
+
+
+def test_formal_prefix_splits_into_level_one_sections() -> None:
+    text = (
+        "SECTION 1. SHORT TITLE.\n"
+        "Body of section one.\n"
+        "SEC. 2. FINDINGS.\n"
+        "Findings body.\n"
+        "SECTION 3. PURPOSE.\n"
+        "Purpose body.\n"
+    )
+
+    canonical = normalize_v2(_bundle(text))
+    children = canonical["root"]["children"]
+
+    assert is_valid("CanonicalDoc", canonical)
+    assert len(children) == 3
+    assert all(c["level"] == 1 for c in children)
+    assert children[0]["title"] == "SECTION 1. SHORT TITLE."
+    assert children[1]["title"] == "SEC. 2. FINDINGS."
+
+
+def test_numbered_glued_splits_into_sections() -> None:
+    text = (
+        "1Definitions used in the Contract\n"
+        "Definitions body text follows.\n"
+        "2Understanding the Contract\n"
+        "Understanding body text follows.\n"
+    )
+
+    canonical = normalize_v2(_bundle(text))
+    children = canonical["root"]["children"]
+
+    assert is_valid("CanonicalDoc", canonical)
+    assert len(children) == 2
+    assert [c["level"] for c in children] == [1, 1]
+    assert children[0]["title"].startswith("1Definitions")
+
+
+def test_density_cap_falls_back_to_single_leaf() -> None:
+    # Every line is heading-like → density 100% > 50% cap; falls back.
+    text = "\n".join(f"{i} Heading {i}" for i in range(1, 11))
+
+    canonical = normalize_v2(_bundle(text))
+    children = canonical["root"]["children"]
+
+    assert is_valid("CanonicalDoc", canonical)
+    assert len(children) == 1
+    assert children[0]["text"] == text
+    assert "title" not in children[0]
+
+
+def test_zero_headings_falls_back_to_single_leaf() -> None:
+    text = "Just a long paragraph with no heading-like lines anywhere."
+
+    canonical = normalize_v2(_bundle(text))
+    children = canonical["root"]["children"]
+
+    assert is_valid("CanonicalDoc", canonical)
+    assert len(children) == 1
+    assert children[0]["text"] == text


### PR DESCRIPTION
## Summary

- `v2_normalize` learns heading detection — three regex families (formal-prefix `SECTION`/`SEC.`/`CHAPTER`/`ARTICLE`/`PART`, numbered `5.1 Title`, glued numbered `1Title`) split the Kreuzberg-extracted plain text into one section node per detected heading, with a 50% density-cap fallback.
- V2 now produces N claims per document instead of one trivial first-sentence-of-everything claim. Legal goes 1 → 22 claims, spec 1 → 98 on the locked prototype samples; invoice and diagram correctly stay at 1.
- `v2_analyze` / `v2_render` / `v2_eval` untouched — they walk the tree and iterate claims, so an N-leaf tree naturally yields N claims and N bullets. No schema change, no new dependency, no `extract.py` change.

Resolves [#33](https://github.com/qte77/doc-pipeline-engine/issues/33).

## Test plan

- [x] `make test` — 110 passed (105 prior + 5 new in `tests/test_stages_v2_normalize_headings.py`).
- [x] `make lint` clean.
- [x] `make lint_md` clean.
- [x] V2-only multi-sample re-run on all five locked samples; results in `docs/prototype/results/2026-04-26-run-3-v2-headings.md`.
- [x] Existing snapshot test (`tests/test_stages_v2_normalize_snapshot.py`) still passes — regression guard for the no-headings fallback shape.

## Out of scope (deferred)

Real nested hierarchy, render-template upgrade (`##` subheadings from `title`), heading-aware `tier_summary`, `extract.py` switch to `include_document_structure=True`, and docling-based normalize — all tracked as follow-ups in the run-3 results doc.

Generated with Claude <noreply@anthropic.com>