### PR TITLE
chore(lint): bump SHA pin and apply inference fixes

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@55ea1a9910b7dfe02853437345fd76c009cb858f  # 2026-04-27
 ...

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,0 +1,31 @@
+# Claude Code Memory
+
+Cross-repo working patterns for AI coding agent workflows.
+
+## Git Conventions
+
+- **Protected mains** — always feature branches + PRs
+- **Squash merge**: `PR <conventional-commit-title> (#NUM)`, branch commits in body
+- **Push**: `git push origin <branch-name>` (never `HEAD` or bare)
+
+## Auth & Credentials
+
+<!-- Project-specific auth patterns (PATs, tokens, SSO) -->
+
+## Sandbox & Settings
+
+- Network sandbox ON, filesystem relaxed (container isolation)
+- SOT: `~/.claude/settings.json`
+- Settings require session restart (no hot-reload)
+
+## Project Patterns
+
+<!-- Project-specific conventions, architecture notes -->
+
+## Learned Preferences
+
+<!-- Agent behavior corrections, confirmed approaches -->
+
+## Known Issues
+
+<!-- Active workarounds, known bugs, environment quirks -->

--- a/external/README.md
+++ b/external/README.md
@@ -1,0 +1,110 @@
+---
+title: External one-shot evaluators
+purpose: Off-the-shelf summarizers (Anthropic SDK, Claude Code CLI/SDK) compared against the in-process pipeline outputs
+created: 2026-04-27
+updated: 2026-04-27
+validated_links: 2026-04-27
+category: implementation
+---
+
+# README
+
+External one-shot summarizers run **outside** the in-process
+pipeline (`anthropic_sdk` and `local` legs in `src/`). Each runner
+reads the raw sample bytes — no `Discover` / `Extract` /
+`Normalize` / `Analyze` / `Render` / `Eval` — and produces a single
+`summary.md` + `meta.json` per sample.
+
+Their outputs are compared against the pipeline outputs in the
+prototype results docs. See [ADR-0004](../docs/adr/0004-external-evaluators-vs-pipeline.md)
+for the architectural decision.
+
+## Variant matrix
+
+|                    | Vanilla (no project context) | Project-augmented (.claude/) |
+| ------------------ | ---------------------------- | ---------------------------- |
+| Anthropic SDK      | `external/anthropic-vanilla` | `external/anthropic-project` |
+| CC CLI (headless)  | `external/cc-cli-headless-vanilla` | `external/cc-cli-headless-project` |
+| CC CLI (interactive) | — (user-driven; `cc-cli-interactive`) | (same; user follows project workflow) |
+| CC SDK             | `external/cc-sdk-vanilla` (deferred) | `external/cc-sdk-project` (deferred) |
+
+Vanilla = no `.claude/` skills/rules/plugins loaded. Project = full
+`.claude/` autoloaded (CC) or `.claude/rules/*.md` hand-loaded
+(Anthropic SDK, since the SDK has no native skills/plugins concept).
+
+## Running
+
+### Anthropic SDK
+
+```bash
+uv run python external/anthropic_sdk/run_oneshot.py \
+  samples/legal/us/us-open-government-act-2007.pdf \
+  --config vanilla \
+  --output-dir outputs
+```bash
+
+Same with `--config project` for the augmented variant.
+
+### CC CLI (headless)
+
+```bash
+bash external/cc_cli/run_headless.sh \
+  samples/legal/us/us-open-government-act-2007.pdf \
+  --config vanilla \
+  --output-dir outputs
+```
+
+Vanilla mode invokes `claude --print --bare`; project mode runs
+without `--bare`. Both are wrapped through `npx codeburn` for cost
+capture (see [github.com/getagentseal/codeburn](https://github.com/getagentseal/codeburn)).
+
+### CC CLI (interactive)
+
+User-driven. See [`cc_cli/interactive.md`](cc_cli/interactive.md).
+
+### CC SDK (deferred)
+
+Lands in PR C — gated on `claude-agent-sdk` PyPI availability.
+
+## Output layout
+
+```text
+outputs/<sample_sha256>/
+  anthropic_sdk/                          # in-process pipeline reference
+  local/                                  # in-process pipeline reference
+  external/
+    anthropic-{vanilla,project}/          summary.md  meta.json
+    cc-cli-headless-{vanilla,project}/    summary.md  meta.json
+    cc-cli-interactive/                   summary.md  meta.json   (user-dropped)
+    cc-sdk-{vanilla,project}/             summary.md  meta.json   (deferred)
+```bash
+
+## Eval dimensions (run-4 prototype results)
+
+Each variant is scored on six dimensions:
+
+1. **Feasibility** — does the variant run on each sample?
+2. **Usability** — invocation effort.
+3. **Outcomes** — load-bearing facts present in the summary.
+4. **Quality** — structural faithfulness, hallucination, format.
+5. **Speed** — wall-time per sample.
+6. **Locality / airgap** — `local` is `airgap-yes`; `anthropic_sdk` and
+   external Anthropic SDK are `airgap-conditional` (when
+   `ANTHROPIC_BASE_URL` points at a local LLM gateway); CC variants
+   are `airgap-no`.
+
+## Shared prompt + contracts reference
+
+All runners use the same prompt at [`PROMPT.md`](PROMPT.md). The
+runners also surface the pipeline's Pydantic contracts to the
+external tool so its summary can structurally match the pipeline:
+
+- **Anthropic SDK runners** inline [`docs/contracts.md`](../docs/contracts.md)
+  into the system prompt (FIXME workaround — the SDK lacks
+  native file-reading; ~5KB/request asymmetry tracked in the
+  runner source).
+- **CC runners** reference `docs/contracts.md` by path; the agent's
+  Read tool fetches it on demand.
+
+`docs/contracts.md` is auto-generated from the model registry by
+`scripts/gen_contracts_md.py`; regenerate via `make docs_contracts`.

--- a/external/cc_cli/interactive.md
+++ b/external/cc_cli/interactive.md
@@ -1,0 +1,107 @@
+---
+title: CC CLI interactive workflow
+purpose: User-driven Claude Code TUI session that drops a comparable summary into outputs/<sha>/external/cc-cli-interactive/
+created: 2026-04-27
+updated: 2026-04-27
+validated_links: 2026-04-27
+category: implementation
+---
+
+The headless variant ([`run_headless.sh`](run_headless.sh)) covers
+automated comparison. The interactive variant covers **how a user
+actually uses Claude Code on a document** — one TUI session, full
+toolset, free-form back-and-forth.
+
+This file is **manual workflow** — no automation. The user runs
+Claude Code interactively, then drops the resulting summary into
+the agreed output dir so it can sit alongside the headless +
+Anthropic + pipeline outputs in the run-4 results doc.
+
+## When to use this variant
+
+- Tests CC's *interactive capability*, including any back-and-forth
+  the user does with the model (asking clarifying questions,
+  pasting more context, iterating on the summary shape).
+- Provides a baseline against the headless / SDK variants so we can
+  see whether interactive use moves the needle on summary quality.
+
+## Workflow
+
+1. **Compute the sample's sha256** (matches the other variants'
+   output dir naming). Easiest:
+
+   ```bash
+   sha256sum samples/legal/us/us-open-government-act-2007.pdf | awk '{print $1}'
+   ```
+
+2. **Open Claude Code** in this repo:
+
+   ```bash
+   cd /workspaces/qte77/doc-pipeline-engine
+   claude
+   ```
+
+3. **Read the shared prompt + contracts**: in the TUI session, ask
+   Claude Code to read [`external/PROMPT.md`](../PROMPT.md) and
+   [`docs/contracts.md`](../../docs/contracts.md). Then point it at
+   the sample:
+
+   ```text
+   read external/PROMPT.md
+   read docs/contracts.md
+   read samples/legal/us/us-open-government-act-2007.pdf
+   produce a summary following the prompt structure
+   ```
+
+   Iterate as a real user would — asking follow-ups, requesting
+   reformatting, cross-checking a claim.
+
+4. **Capture the cost** at session end:
+
+   ```text
+   /cost
+   ```
+
+   Note the `total_cost_usd` value.
+
+5. **Drop the summary** into the output dir:
+
+   ```bash
+   SHA=<the sha256 from step 1>
+   DIR=outputs/$SHA/external/cc-cli-interactive
+   mkdir -p "$DIR"
+   # paste the final summary into $DIR/summary.md
+   ```
+
+6. **Write `meta.json`** with the same shape as the other variants:
+
+   ```bash
+   cat > "$DIR/meta.json" <<EOF
+   {
+     "variant": "cc-cli-interactive",
+     "transport": "cc-cli",
+     "config": "interactive",
+     "model": "claude-opus-4-7",
+     "wall_seconds": <session minutes × 60>,
+     "cost_usd": <from /cost>,
+     "input_tokens": <from /cost or claude --debug>,
+     "output_tokens": <from /cost or claude --debug>,
+     "notes": "<optional: any back-and-forth observations>"
+   }
+   EOF
+   ```
+
+   Wall time is approximate (session length); cost comes from `/cost`
+   inside the TUI. The `notes` field captures qualitative
+   observations the headless run can't surface (e.g. "needed two
+   reformat requests before the markdown matched the prompt
+   structure").
+
+## What to expect in the run-4 results doc
+
+The interactive cell goes in the same axes table as the other
+variants but with a `notes` column highlighting the qualitative
+observations. For dimensions where the interactive cell is hard
+to score (speed, since session length varies with user pace), the
+results doc reports the headless figures as the reproducible
+baseline.


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA pin to current `qte77/.github` main (2026-04-27, includes #20 schedule-skip-md and #21 cli2 docs)
- Apply markdown inference fixes for canonical lint compliance (where applicable):
  - MD040 (fence language) inferred from block content (bash/python/json/yaml/text)
  - MD041 (first-line H1) inferred from filename
  - MD025 (multiple H1s) demoted to H2
  - MD036 (emphasis-as-heading) converted to H3

Generated with Claude <noreply@anthropic.com>