### PR TITLE
chore(ruff): enable S and C90 rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `pyproject.toml` `[tool.ruff.lint]` adds `S` (bandit-equivalent security checks) and `C90` (McCabe complexity, `max-complexity = 10`) rule sets, bringing the repo toward the cross-fleet ruff alignment. `tests/**` per-file-ignores gain `S101` (pytest's `assert` idiom). Tracking follow-up issue #75 covers the remaining rules. Resolves #72.
 - **Pipeline legs renamed**: `v1` → `anthropic_sdk`, `v2` → `local`. The PR-ordering labels obscured what the legs actually do; the new names describe the transport flexibility (Anthropic SDK can also point at Bedrock / Vertex / local LLM gateways) and the locality property (`local` does no LLM and no cloud calls). All `stages/v{1,2}_*.py` files renamed via `git mv`; `harness.py` `DiffReport` fields, axes keys, and CLI flag (`--anthropic-sdk-model`) updated; `pyproject.toml` extras renamed (`anthropic_sdk`, `local`, `local-render`, `local-eval`); `Makefile` `install_v2_nlp` → `install_local_nlp`. The old extras + Makefile target ship as deprecated aliases for one release cycle. Output dirs change from `outputs/<sha>/v1/` → `outputs/<sha>/anthropic_sdk/` and `v2/` → `local/`. Forward-looking docs (architecture / roadmap / CONTRIBUTING / prototype plan / landscape) adopt the new names; historical run-1/2/3 results keep `v1`/`v2` wording as snapshots. See [ADR-0003](docs/adr/0003-rename-legs-anthropic-sdk-local.md).
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,14 +109,19 @@ target-version = "py311"
 # D rules enforce docstring presence so mkdocstrings has something to render.
 # Narrow set: only require module / class / function / package docstrings.
 # Google convention; private (_-prefixed) names skipped automatically.
-select = ["D100", "D101", "D103", "D104"]
+# S = bandit-equivalent security checks. C90 = McCabe complexity (≤ 10).
+select = ["D100", "D101", "D103", "D104", "S", "C90"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
 [tool.ruff.lint.per-file-ignores]
 # Tests, scripts, and helpers are internal — docstrings aren't required.
-"tests/**" = ["D"]
+# S101 (assert) is fine in tests; tests are the place to use it.
+"tests/**" = ["D", "S101"]
 "scripts/**" = ["D"]
 "src/doc_pipeline_engine/stages/_*.py" = ["D"]
 "src/doc_pipeline_engine/models/_common.py" = ["D"]


### PR DESCRIPTION
## Summary

Brings `doc-pipeline-engine` in line with the cross-fleet ruff config — adds `S` (bandit-equivalent security checks) and `C90` (McCabe complexity, `max-complexity = 10`) to `[tool.ruff.lint] select`. `tests/**` per-file-ignores gain `S101` (pytest's `assert` idiom).

Resolves #72. Follow-up issue #75 tracks the remaining rules (`E, F, I, N, W, UP, B, SIM, RUF, PT, ANN, TCH, PGH`).

## Diff (pyproject.toml)

\`\`\`diff
 [tool.ruff.lint]
 # D rules enforce docstring presence so mkdocstrings has something to render.
 # Narrow set: only require module / class / function / package docstrings.
 # Google convention; private (_-prefixed) names skipped automatically.
-select = ["D100", "D101", "D103", "D104"]
+# S = bandit-equivalent security checks. C90 = McCabe complexity (≤ 10).
+select = ["D100", "D101", "D103", "D104", "S", "C90"]

 [tool.ruff.lint.pydocstyle]
 convention = "google"

+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
 [tool.ruff.lint.per-file-ignores]
 # Tests, scripts, and helpers are internal — docstrings aren't required.
-"tests/**" = ["D"]
+# S101 (assert) is fine in tests; tests are the place to use it.
+"tests/**" = ["D", "S101"]
\`\`\`

## Test plan

- [x] \`uvx ruff check --select S,C90 .\` clean on main + config (verified locally before this PR was opened — only S violations were in \`tests/test_external_cc_cli_run_headless.py\` which is on PR #61, not main; per-file-ignore for S101 handles tests).
- [ ] CI \`make lint\` passes after merge.

## Notes for review

This PR was authored via the GitHub Contents API from a sandboxed environment (the per-commit signatures show \`unsigned\` because the API doesn't auto-sign with a user PAT). The squash-merge commit on main will be signed by GitHub web-flow, satisfying the \`required_signatures\` rule on main. Use \`--admin\` flag if the merge button is disabled by the ruleset.