### PR TITLE
chore(deps): pin Kreuzberg to MIT line (<4.8) + opt-in ELv2 extra (resolves #76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pin `extract` extra to `kreuzberg>=2.0,<4.8` to stay on the MIT line (v4.7.4 is the last MIT release; upstream relicensed to Elastic License 2.0 starting at v4.8.0 on 2026-04-08). New opt-in `[kreuzberg-elv2]` extra (`kreuzberg>=4.8`) for downstream consumers comfortable with ELv2 restrictions (no managed-service offering, no notice removal). Default install path stays Apache-2.0-clean. See [ADR-0005](docs/adr/0005-kreuzberg-elv2-mitigation.md). Resolves #76.
 
-
 ## [0.1.0] - 2026-04-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `anthropic_sdk` leg of the parallel-diff harness runs in subscription-only environments (claude CLI but no `ANTHROPIC_API_KEY`). Previously crashed at `_anthropic_sdk_client.make_client()`.
 - `_anthropic_sdk_client._call_via_cli` passes the user prompt via stdin (was hitting argv length limit on the 220K-char contract DOCX).
 
+### Security
+
+- Pin `extract` extra to `kreuzberg>=2.0,<4.8` to stay on the MIT line (v4.7.4 is the last MIT release; upstream relicensed to Elastic License 2.0 starting at v4.8.0 on 2026-04-08). New opt-in `[kreuzberg-elv2]` extra (`kreuzberg>=4.8`) for downstream consumers comfortable with ELv2 restrictions (no managed-service offering, no notice removal). Default install path stays Apache-2.0-clean. See [ADR-0005](docs/adr/0005-kreuzberg-elv2-mitigation.md). Resolves #76.
+
 
 ## [0.1.0] - 2026-04-23
 

--- a/docs/adr/0005-kreuzberg-elv2-mitigation.md
+++ b/docs/adr/0005-kreuzberg-elv2-mitigation.md
@@ -1,0 +1,106 @@
+---
+title: ADR-0005 — Kreuzberg ELv2 mitigation
+purpose: Records the decision to pin the `extract` extra to the last MIT release of Kreuzberg (v4.7.4) and gate the ELv2 line behind an opt-in extra, with docling as the documented fallback path if v4.7.4 quality regresses
+created: 2026-05-21
+updated: 2026-05-21
+validated_links: 2026-05-21
+category: technical
+---
+
+**Status**: Proposed (pending v4.7.4 DOCX verification — see Verification below)
+
+## Context
+
+Kreuzberg upstream relicensed from MIT to Elastic License 2.0 (ELv2) on 2026-04-08 (commit `5bfd393`). The first ELv2 release is v4.8.0 (7 minutes after the licence-change commit). The pinned version in `uv.lock` at the time of decision is v4.9.5 — **already on ELv2**.
+
+ELv2 is source-available but not OSI-open-source. It prohibits:
+
+1. Offering the software (or derivatives) as a managed/hosted service to third parties.
+2. Removing or altering licence / copyright / attribution notices.
+3. Asserting patent claims against the licensor (terminates the licence).
+
+This directly conflicts with the project's own positioning:
+
+- [`docs/landscape/ingest.md`](../landscape/ingest.md) selection criterion #1: *"License compatibility — must not force Apache-2.0 consumers into copyleft obligations. AGPL/GPL tools are optional-only."* ELv2 is not copyleft but is more restrictive than the criterion allows for a default dep.
+- [`docs/landscape/e2e-systems.md`](../landscape/e2e-systems.md) §5 gap-analysis claim #3: *"Strict license isolation — Apache-2.0 default."*
+
+Downstream consumers (polyforge, office-polyforge, qte77 fleet) ship with `--extra extract` and would inherit ELv2 restrictions through Kreuzberg. The embeddable-engine USP fails for any consumer that wants to offer the result as a managed service.
+
+## Decision
+
+Pin the `extract` extra to `kreuzberg>=2.0,<4.8` (MIT line, frozen at v4.7.4). Add a new `kreuzberg-elv2` opt-in extra (`kreuzberg>=4.8`) for downstream consumers who explicitly accept ELv2. Pattern mirrors the existing PyMuPDF (AGPL) and Apache Tika (JVM) opt-in gates.
+
+The default install path stays Apache-2.0-clean. Opt-in is one-line and documented.
+
+## Verification gate (before this ADR moves to Accepted)
+
+Discussion [#375](https://github.com/kreuzberg-dev/kreuzberg/discussions/375) upstream reports DOCX heading detection broken in v4.x. The `chore/v5-prep` branch has commit `d2f5d47413 fix(docx): restore markdown formatting markers` — meaning upstream acknowledges the regression. **Unknown:** whether v4.7.4 (the pin target) has the regression or whether it was introduced later in the v4.x line.
+
+Before merging this ADR, verify v4.7.4 DOCX heading parity against the project's `samples/*.docx` corpus. Procedure (run outside the sandbox):
+
+```bash
+# Two isolated venvs, one per version.
+uv venv /tmp/k-mit  && /tmp/k-mit/bin/pip install 'kreuzberg==4.7.4'
+uv venv /tmp/k-elv2 && /tmp/k-elv2/bin/pip install 'kreuzberg==4.9.5'
+
+SAMPLE=samples/<category>/<your-docx-file>.docx
+
+for ver in /tmp/k-mit /tmp/k-elv2; do
+  $ver/bin/python -c "
+import asyncio, sys
+from kreuzberg import extract_file
+async def main(p):
+    r = await extract_file(p)
+    print(r.content)
+asyncio.run(main(sys.argv[1]))
+" $SAMPLE > $(basename $ver).txt
+done
+
+# Heading-marker measurement (regex families from local_normalize).
+python -c "
+import re, pathlib
+patterns = {
+  'formal':    r'^(?:SECTION|SEC\\.|CHAPTER|ARTICLE|PART)\\s+[\\dIVXLCM]+',
+  'numbered':  r'^\\d+(?:\\.\\d+)*\\s+\\S',
+  'glued':     r'^\\d+(?:\\.\\d+)*[A-Z][a-z]',
+  'markdown':  r'^#{1,6}\\s+\\S',
+}
+for f in ('k-mit.txt', 'k-elv2.txt'):
+    t = pathlib.Path(f).read_text()
+    print(f, {n: len(re.findall(p, t, flags=re.M)) for n,p in patterns.items()})
+"
+```
+
+**Interpretation:**
+
+- v4.7.4 shows ≥5 matches AND v4.9.5 ≈ 0 → regression at v4.8; pin is a clean win. **Move ADR to Accepted.**
+- Both versions show ≥5 matches → pin is still a win on locality (MIT) but DOCX quality isn't the deciding factor. **Move ADR to Accepted.**
+- Both ≈ 0 → regression predates v4.7.4. **This ADR is wrong-headed.** Close this PR and start the Option B follow-up: switch `Extract` primary to docling, demote Kreuzberg to long-tail fallback only.
+
+## Rejected alternatives
+
+- **Accept ELv2 at v4.8+**: kills the load-bearing license-isolation USP (`e2e-systems.md` §5 claim #3). Even for non-SaaS downstream consumers, the licence creates audit and notice obligations that contradict the project's "Apache-2.0 default, no compliance overhead" promise.
+- **Drop Kreuzberg, switch to docling unconditionally**: viable but loses the long-tail format coverage (email, legacy Office, broad image OCR). Documented as the conditional fallback if v4.7.4 verification fails (see above).
+- **Request upstream to publish a `kreuzberg-mit` slim package**: refuted by precedent. Five-of-five comparable license pivots (Elasticsearch 2021, MongoDB 2018, Redis 2024, Terraform 2023, Sentry 2019) had *zero* cases of upstream publishing a permissive slim subpackage. The community response in every case was external fork (OpenSearch, OpenTofu, Valkey) or downstream acceptance, never upstream split. Goldziher's Discussion [#842](https://github.com/kreuzberg-dev/kreuzberg/discussions/842) explicitly invokes Elasticsearch as the analogy, signalling conscious adoption of that model. Filing the request would burn an issue slot and signal naïveté.
+- **Fork v4.7.4 as a long-term `kreuzberg-mit` maintained externally**: the closest non-upstream version of the "publish slim package" idea. Defensible but expensive — would require ongoing security fixes against a frozen base. Defer until evidence of community gravity (≥10 downstream consumers requesting it). Not a v0.1.x decision.
+
+## Consequences
+
+- **v4.7.4 is frozen.** No upstream security fixes will arrive on the MIT line. Periodic `pip-audit` / Dependabot review of v4.7.4's own transitive deps required.
+- **Default install path is Apache-2.0-clean.** Downstream consumers (polyforge, office-polyforge) gain explicit licence-isolation guarantees.
+- **`uv.lock` regeneration required** — run `uv lock --upgrade-package kreuzberg` after this PR merges; current pin (`4.9.5`) violates the new constraint.
+- **CHANGELOG entry under `### Security`** rather than `### Changed` — the relicense is a security-policy concern from the embeddable-engine USP perspective, not a feature tweak.
+- **§0.5.0 domain packs unblocked** — `med-research-patents` and `mech-elec-cert` consumers can ship without the ELv2 audit overhead.
+- **Track `chore/v5-prep` upstream.** If v5 ships with materially better DOCX/email *under ELv2*, the calculus may shift — re-evaluate in a future ADR.
+- **Verification result must be appended** to this ADR before moving to Accepted (or the PR closed if verification fails).
+
+## Sources
+
+- Kreuzberg LICENSE migration commit: <https://github.com/kreuzberg-dev/kreuzberg/commit/5bfd393>
+- Elastic License 2.0 text: <https://www.elastic.co/licensing/elastic-license>
+- Issue [#76](https://github.com/qte77/doc-pipeline-engine/issues/76) — the originating critical issue.
+- Discussion #375 upstream (DOCX heading regression): <https://github.com/kreuzberg-dev/kreuzberg/discussions/375>
+- Discussion #842 upstream (Goldziher on ELv2 rationale): <https://github.com/kreuzberg-dev/kreuzberg/discussions/842>
+- Precedent table (relicense pivots that did NOT publish permissive slim subpackages): Elasticsearch (SSPL/ELv2 2021-01) — <https://github.com/opensearch-project/OpenSearch>; MongoDB (SSPL 2018-10); Redis (RSALv2/SSPLv1 2024-03) — <https://github.com/valkey-io/valkey>; HashiCorp Terraform (BUSL 2023-08) — <https://github.com/opentofu/opentofu>; Sentry (BSL 2019-10).
+- [`docs/landscape/ingest.md`](../landscape/ingest.md) Kreuzberg row + Notes block.
+- [`docs/landscape/domain-extraction.md`](../landscape/domain-extraction.md) License-tier reference (tier G — Undeclared / NOASSERTION) cites the Kreuzberg case as motivation.

--- a/docs/landscape/ingest.md
+++ b/docs/landscape/ingest.md
@@ -25,7 +25,7 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 | Tool | Primary role | License | Runtime | Formats | Verdict |
 | --- | --- | --- | --- | --- | --- |
 | **docling** | Layout-aware PDF/Office → structured doc | MIT | Python + torch | PDF, DOCX, PPTX, HTML, images | **Primary** — best layout fidelity, native target for `CanonicalDoc`. |
-| **Kreuzberg** | Async multi-format extraction facade | MIT | Python (pypdfium2, Tesseract, python-docx, …) | PDF, Office, images, email, HTML | **Primary (breadth)** — covers the long tail with one adapter. |
+| **Kreuzberg** | Async multi-format extraction facade | **MIT (≤ v4.7.4) / ELv2 (≥ v4.8)** | Python (pypdfium2, Tesseract, python-docx, …) | PDF, Office, images, email, HTML | **Primary (breadth, MIT line via `extract`) / Opt-in (ELv2 line via `kreuzberg-elv2`)** — long-tail breadth; default pin is MIT v4.7.4. See [ADR-0005](../adr/0005-kreuzberg-elv2-mitigation.md). |
 | **claude_cli_adapter** | LLM-based extraction via Claude Code CLI | n/a (our code) | Claude CLI | Any (LLM-mediated) | **Primary (reference)** — end-to-end wired first; cross-validation baseline. |
 | **GLM-OCR** | Vision-LLM OCR for complex scans | Apache-2.0 | GPU preferred | Images, scanned PDF | Stub adapter — specialized scan/handwriting path. |
 | **PaddleOCR-VL** | Vision-LLM OCR, CJK-strong | Apache-2.0 | GPU preferred | Images, scanned PDF | Stub adapter — non-Latin script fallback. |
@@ -35,7 +35,7 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 
 ### Notes
 
-**docling vs Kreuzberg** — not redundant. docling is the layout-accurate path for PDFs that feed `CanonicalDoc`; Kreuzberg is the pragmatic catch-all for the formats docling doesn't handle well (email, xlsx, legacy Office). Run them side by side in [§0.4.0](../roadmap.md#040--adapters) cross-validation.
+**docling vs Kreuzberg** — not redundant. docling is the layout-accurate path for PDFs that feed `CanonicalDoc`; Kreuzberg is the pragmatic catch-all for the formats docling doesn't handle well (email, xlsx, legacy Office). Run them side by side in [§0.4.0](../roadmap.md#040--adapters) cross-validation. **Kreuzberg licence-gate (2026-04-08):** v4.8+ moved to Elastic License 2.0; default pin is `<4.8` (MIT, frozen at v4.7.4). If v4.7.4 DOCX heading detection regresses for your samples, docling becomes the primary DOCX path (see [ADR-0005](../adr/0005-kreuzberg-elv2-mitigation.md)).
 
 **Tesseract positioning** — don't expose as its own adapter. It's a dependency of the Python wrappers; surfacing it separately would duplicate configuration surface for no gain.
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -52,6 +52,7 @@ nav:
       - "ADR-0002 mkdocs site": adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
       - "ADR-0003 Rename legs": adr/0003-rename-legs-anthropic-sdk-local.md
       - "ADR-0004 External evaluators": adr/0004-external-evaluators-vs-pipeline.md
+      - "ADR-0005 Kreuzberg ELv2 mitigation": adr/0005-kreuzberg-elv2-mitigation.md
   - Contracts: contracts.md
   - Code: docstrings.md
   - Agents:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,19 @@ dependencies = [
 [project.optional-dependencies]
 # Install with: uv sync --extra extract
 # Kreuzberg covers PDF/Office/images/email/text via Tesseract+pypdfium2.
-# MIT, local-only, no cloud.
+# MIT (≤ v4.7.4) — pinned to the last MIT release. Upstream relicensed to
+# Elastic License 2.0 starting at v4.8.0 (2026-04-08); see ADR-0005 and issue #76.
+# For the ELv2 line, install the [kreuzberg-elv2] extra instead.
 extract = [
-  "kreuzberg>=2.0",
+  "kreuzberg>=2.0,<4.8",
+]
+# Install with: uv sync --extra kreuzberg-elv2
+# Latest Kreuzberg under Elastic License 2.0 (source-available, not OSI-OSS).
+# ELv2 restricts offering the software as a managed/hosted service to third
+# parties. Use only if your deployment is comfortable with that constraint.
+# See ADR-0005.
+kreuzberg-elv2 = [
+  "kreuzberg>=4.8",
 ]
 # Install with: uv sync --extra render
 # Shared rendering: Markdown → HTML → PDF (WeasyPrint), Markdown → DOCX (python-docx).


### PR DESCRIPTION
## Summary

Kreuzberg upstream relicensed from MIT to Elastic License 2.0 starting at v4.8.0 (2026-04-08). Our `uv.lock` pin (v4.9.5) is already on ELv2, contradicting the project's license-isolation USP. This PR pins the default `extract` extra to `kreuzberg>=2.0,<4.8` (last MIT release: v4.7.4) and adds a `kreuzberg-elv2` opt-in extra for downstream consumers who accept ELv2.

Resolves #76.

## Changes

- `pyproject.toml` — `extract` extra now `kreuzberg>=2.0,<4.8`; new `kreuzberg-elv2 = ["kreuzberg>=4.8"]` extra.
- `docs/landscape/ingest.md` — Kreuzberg row updated (License column shows MIT/ELv2 split; Verdict gated); Notes block flags the licence gate + docling-fallback condition.
- `docs/adr/0005-kreuzberg-elv2-mitigation.md` — **new ADR**. Records the decision + rejected alternatives (including the "upstream MIT slim package" idea, which was refuted by 5/5 precedent — see ADR-0005 Rejected alternatives section).
- `mkdocs.yaml` — ADR-0005 nav entry.
- `CHANGELOG.md` — \`### Security\` entry under \`[Unreleased]\`.

## Status: ADR-0005 is Proposed, not Accepted

ADR-0005 includes a verification gate. Upstream Discussion #375 reports DOCX heading detection broken in v4.x; the `chore/v5-prep` branch has a fix commit. **Unknown:** whether v4.7.4 (the pin target) has the regression.

**Do not merge before the verification gate is completed.** Procedure copied from ADR-0005:

\`\`\`bash
uv venv /tmp/k-mit  && /tmp/k-mit/bin/pip install 'kreuzberg==4.7.4'
uv venv /tmp/k-elv2 && /tmp/k-elv2/bin/pip install 'kreuzberg==4.9.5'

SAMPLE=samples/<category>/<your-docx-file>.docx

for ver in /tmp/k-mit /tmp/k-elv2; do
  \$ver/bin/python -c "
import asyncio, sys
from kreuzberg import extract_file
async def main(p):
    r = await extract_file(p)
    print(r.content)
asyncio.run(main(sys.argv[1]))
" \$SAMPLE > \$(basename \$ver).txt
done

python -c "
import re, pathlib
patterns = {
  'formal':    r'^(?:SECTION|SEC\\\\.|CHAPTER|ARTICLE|PART)\\\\s+[\\\\dIVXLCM]+',
  'numbered':  r'^\\\\d+(?:\\\\.\\\\d+)*\\\\s+\\\\S',
  'glued':     r'^\\\\d+(?:\\\\.\\\\d+)*[A-Z][a-z]',
  'markdown':  r'^#{1,6}\\\\s+\\\\S',
}
for f in ('k-mit.txt', 'k-elv2.txt'):
    t = pathlib.Path(f).read_text()
    print(f, {n: len(re.findall(p, t, flags=re.M)) for n,p in patterns.items()})
"
\`\`\`

**Decision tree** (from ADR-0005):

- v4.7.4 shows >=5 matches AND v4.9.5 ~ 0 → regression at v4.8; **merge this PR.** Move ADR-0005 to Accepted.
- Both >=5 matches → DOCX quality fine on both; **merge this PR.** Pin still wins on locality (MIT). Move ADR-0005 to Accepted.
- Both ~ 0 → regression predates v4.7.4. **Close this PR.** Trigger Option B follow-up: switch `Extract` primary to docling, demote Kreuzberg to long-tail fallback only.

## Pre-merge checklist

- [ ] Run the verification procedure above against at least 2 DOCX samples (legal contract + bid-tender are the obvious picks).
- [ ] Append verification result table to ADR-0005 (under a new \`## Verification result\` section).
- [ ] Move ADR-0005 status \`Proposed\` to \`Accepted\` (if verification passes) **or** close this PR (if verification fails).
- [ ] Regenerate \`uv.lock\`: \`uv lock --upgrade-package kreuzberg\` (current pin v4.9.5 violates the new constraint; lockfile will fail validation until regenerated).
- [ ] \`make validate\` clean.

## Notes for review

- ADR-0005 documents *why* we're not asking upstream to publish a slim MIT subpackage. Five-for-five precedent (Elasticsearch, MongoDB, Redis, Terraform, Sentry) showed no comparable license pivot resulted in upstream publishing such a package; the standard response is external fork (OpenSearch, OpenTofu, Valkey) or downstream acceptance. Goldziher's Discussion #842 explicitly invokes Elasticsearch as the analogy.
- The new opt-in extra (`kreuzberg-elv2`) mirrors the existing PyMuPDF (AGPL) and Apache Tika (JVM) opt-in patterns.

## Sources

- [ADR-0005](docs/adr/0005-kreuzberg-elv2-mitigation.md) — full decision record with rejected alternatives and verification procedure.
- Kreuzberg LICENSE migration commit: https://github.com/kreuzberg-dev/kreuzberg/commit/5bfd393
- Discussion #375 upstream (DOCX heading regression): https://github.com/kreuzberg-dev/kreuzberg/discussions/375
- Discussion #842 upstream (Goldziher on ELv2 rationale): https://github.com/kreuzberg-dev/kreuzberg/discussions/842

**Do not merge before the verification gate above is completed.**