### PR TITLE
chore(gitignore): add MEMORY.md (cc-meta hook seed artifact)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ docs/LICENSE.md
 
 # Claude Code (machine-local settings only)
 .claude/settings.local.json
+
+# cc-meta hook seed artifact — project agent memory, not committed
+MEMORY.md


### PR DESCRIPTION
## Summary

Adds `MEMORY.md` to `.gitignore`. The file is auto-generated by the Claude Code `cc-meta` hook (project agent memory); should never be committed.

This was originally going to land via commit `0ed73b1` ("chore: gitignore MEMORY.md (cc-meta hook seed artifact)") on the external-evaluators feature branch, but that commit was unsigned and got dropped during the PR #61 re-sign cycle. Re-applying as a tiny standalone PR.

## Change

```diff
 # Claude Code (machine-local settings only)
 .claude/settings.local.json
+
+# cc-meta hook seed artifact — project agent memory, not committed
+MEMORY.md
```

## Test plan

- [x] `git check-ignore MEMORY.md` returns the new gitignore line post-merge.
- [x] No tracked file is removed or affected.