### PR TITLE
chore(changelog): drop duplicate blank line (MD012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `anthropic_sdk` leg of the parallel-diff harness runs in subscription-only environments (claude CLI but no `ANTHROPIC_API_KEY`). Previously crashed at `_anthropic_sdk_client.make_client()`.
 - `_anthropic_sdk_client._call_via_cli` passes the user prompt via stdin (was hitting argv length limit on the 220K-char contract DOCX).
 
-
 ## [0.1.0] - 2026-04-23
 
 ### Added


### PR DESCRIPTION
## Summary

- Removes the duplicate blank line between the `Fixed` entry and `## [0.1.0] - 2026-04-23` in `CHANGELOG.md` (was lines 66-67 on main).
- markdownlint MD012 (`no-multiple-blanks`) violation. Latent on main — the lint workflow only flagged it on PR #88 because that PR is the first to touch a path that re-runs the rule against the file.
- Same one-line fix as the one already landed on the #88 branch (`48574e5`), applied to main so the next CHANGELOG-touching PR doesn't trip on it.

## Test plan

- [x] `lint / markdown` passes on this PR
- [x] No content change — only whitespace