### PR TITLE
docs(landscape): audit 2026-05-25 — add adaptive-chunking, Knowhere, MinerU + apply #77

### DIFF
--- a/docs/landscape/e2e-systems.md
+++ b/docs/landscape/e2e-systems.md
@@ -2,8 +2,8 @@
 title: E2E Systems Landscape
 purpose: End-to-end document pipeline systems and prior art — academic surveys, OSS systems, commercial IDP, reference architectures, gap analysis
 created: 2026-04-26
-updated: 2026-05-21
-validated_links: 2026-04-26
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: landscape
 ---
 
@@ -35,17 +35,22 @@ This file informs USP positioning. It is *not* a buyer's guide.
 
 | System | License | E2E scope | Position |
 | --- | --- | --- | --- |
-| **SciPhi-AI / R2R** ([repo](https://github.com/SciPhi-AI/R2R)) | Apache-2.0 | Ingest (PDF/DOCX/MD/MP3/PNG…), chunk, embed, KG extraction, hybrid search, agentic RAG, REST API | **Closest competitor** by feature surface. Difference: R2R is a deployed *service* (REST + Postgres + Docker compose); we are an *embeddable engine* with JSON contracts. |
+| **SciPhi-AI / R2R** ([repo](https://github.com/SciPhi-AI/R2R)) | **MIT** (changed from Apache-2.0) | Ingest (PDF/DOCX/MD/MP3/PNG…), chunk, embed, KG extraction, hybrid search, agentic RAG, REST API | **Closest competitor (maintenance stall)** — 8k stars. Last commit 2025-11-07; last release v3.6.5 (2025-06-06). Architecture remains the closest competitor by feature surface; velocity has collapsed. R2R is a deployed *service* (REST + Postgres + Docker compose); we are an *embeddable engine* with JSON contracts. R2R stall strengthens claim 1 (embeddable differentiator). |
+| **Ontos-AI / Knowhere** ([repo](https://github.com/Ontos-AI/knowhere)) | Apache-2.0 | Parse (MinerU default) → tree-hierarchy reconstruction → multi-modal VLM enrichment (table/image summaries) → cross-doc graph → agentic retrieval (RRF + tree/graph navigation + cited evidence); API + worker + dashboard + Postgres/Redis/S3 via Docker Compose | **Closest competitor (parallel to R2R)** — open-sourced 2026-05-07. Same E2E shape, deployed-service architecture. Cloud LLM/VLM by default (DeepSeek text, Qwen-VL OCR; swappable via env). Their "tree-like hierarchy" maps onto our `CanonicalDoc.root`; multi-modal VLM enrichment + cross-doc graph go beyond our current roadmap. Embeddable-vs-service differentiator (§5.1) and data-locality contract (§5.4) still hold. |
 | **Unstructured.io** ([repo](https://github.com/Unstructured-IO/unstructured)) | Apache-2.0 (OSS core) + commercial API | Ingest + element-typed extraction + chunking; downstream RAG via partner libs | **Adjacent** — already a candidate processor (see [process.md](process.md)). Scope is ingest+extract; we cover all five stages with strict contracts. |
-| **LlamaIndex + LlamaParse + Agentic Document Workflows** ([LlamaIndex](https://github.com/run-llama/llama_index)) | MIT (LlamaIndex), commercial (LlamaParse) | Parse → index → agentic workflow over docs | **Inspiration, not competitor** — we *use* LlamaIndex as a candidate framework; ADW is one possible orchestration pattern over our stages. |
+| **LlamaIndex + LlamaParse + Agentic Document Workflows** ([LlamaIndex](https://github.com/run-llama/llama_index)) | MIT (LlamaIndex), commercial (LlamaParse) | Parse → index → agentic workflow over docs | **Inspiration, increasingly competitive** — 50k stars, v0.14.22 (2026-05-20). LlamaIndex has rebranded as "the leading document agent and OCR platform"; Agentic Document Workflows increasingly overlap with our E2E scope. We still *use* LlamaIndex as a candidate framework, but its positioning has shifted from pure library toward competitor. Monitor. |
 | **Haystack (deepset)** ([repo](https://github.com/deepset-ai/haystack)) | Apache-2.0 | Pipeline DAG over retriever / reader / generator nodes | **Alternative framework** — graph-based pipeline; heavier than needed for embedded use. |
 | **Docling** ([repo](https://github.com/docling-project/docling)) | MIT | Layout-aware extraction → DoclingDocument | **Already wired** as a primary extraction adapter. |
-| **AWS GenAI IDP Accelerator** ([repo](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws)) | Apache-2.0 | OCR → Bedrock classify → extract → assess → validate → summarize; SAML/OIDC SSO; private VPC; multi-model | **Vendor-locked competitor** — covers same E2E shape, but tied to AWS Bedrock + CloudFormation/CDK/Terraform. We are cloud-agnostic and embeddable. |
-| **AWS Sample IDP Pipeline (multimodal)** ([repo](https://github.com/aws-samples/sample-aws-idp-pipeline)) | Apache-2.0 | Multimodal (PDF/video/audio/image), hybrid search + KG, conversational UI | Reference architecture; explicitly not for production. |
+| **AWS GenAI IDP Accelerator** ([repo](https://github.com/aws-solutions-library-samples/accelerated-intelligent-document-processing-on-aws)) | **MIT-0** (changed from Apache-2.0) | OCR → Bedrock classify → extract → assess → validate → summarize; SAML/OIDC SSO; private VPC; multi-model | **Vendor-locked competitor** — 246 stars. Covers same E2E shape, but tied to AWS Bedrock + CloudFormation/CDK/Terraform. We are cloud-agnostic and embeddable. |
+| **AWS Sample IDP Pipeline (multimodal)** ([repo](https://github.com/aws-samples/sample-aws-idp-pipeline)) | Amazon Software License (proprietary; GitHub API returns NOASSERTION — confirmed by reading LICENSE) | Multimodal (PDF/video/audio/image); stack: Strands Agents + Step Functions + LanceDB; hybrid search + KG, conversational UI | Reference architecture; explicitly not for production. Note: Amazon Software License is proprietary — cannot redistribute or use as a library dep. |
 | **AWS aws-ai-intelligent-document-processing** ([repo](https://github.com/aws-samples/aws-ai-intelligent-document-processing)) | Apache-2.0 | Workshop materials + agentic IDP (Analyzer/Matcher/Extractor/Validator/Troubleshooter) | Reference patterns for agent role decomposition. |
-| **Document Processing for Regulated Industries** ([repo](https://github.com/aws-samples/document-processing-pipeline-for-regulated-industries)) | Apache-2.0 | Image/PDF processing with lineage and pipeline-ops metadata | Lineage pattern reference for [§0.5.0](../roadmap.md#050--domain-packs) audit / `local-only` profile. |
-| **thetanishqrathore / IDP** ([repo](https://github.com/thetanishqrathore/IDP)) | Apache-2.0 | RAG-focused: hybrid search (vector + BM25 RRF), context-aware chunking, FastAPI + Qdrant | Solo-maintained; useful as a chunking-strategy reference. |
-| **Awesome Document Understanding** ([repo](https://github.com/tstanislawek/awesome-document-understanding)) | CC-BY (typical for awesome-lists) | Curated index of DU / IDP / RPA resources | Discovery aid for further candidates. |
+<!-- Removed: aws-samples/document-processing-pipeline-for-regulated-industries — dormant since 2021-10-25 (4+ years stale, 67 stars); no longer a useful reference. -->
+| **thetanishqrathore / IDP** ([repo](https://github.com/thetanishqrathore/IDP)) | MIT | Production-grade RAG + Document AI: hybrid search (vector + BM25 RRF), layout-aware chunking, strict citation grounding, Headless API (n8n/Zapier), React UI, FastAPI + Qdrant + Docker | Solo-maintained; last push 2025-12-31. Self-describes as production-grade platform. More substantial than originally noted; useful as a full-stack architecture reference. |
+| **Awesome Document Understanding** ([repo](https://github.com/tstanislawek/awesome-document-understanding)) | no licence declared | Curated index of DU / IDP / RPA resources | Discovery aid — dormant since 2023-06-02; 2k stars. Low maintenance; mine for historical candidates only. |
+| **DocETL** ([repo](https://github.com/ucbepic/docetl)) | MIT | Agentic LLM pipeline DSL (UC Berkeley EPIC); operators over document collections with LLM-based plan optimization | **Candidate (academic + OSS)** — v0.2.6 (2026-05-20), 4k stars. Direct counterpoint to JSON-contract approach: declarative DSL where LLM chooses operator sequencing. Straddles §1 (academic) and §2 (OSS). |
+| **Kreuzberg** ([repo](https://github.com/kreuzberg-dev/kreuzberg)) | Elastic License 2.0 (ELv2; GitHub API returns NOASSERTION — confirmed by reading LICENSE) | Async multi-format extraction facade; covers PDF, Office, images, email, HTML in one API | **Adjacent extraction layer** — v4.9.8 (2026-05-25), 8k stars. Already the primary breadth adapter in [ingest.md §1](ingest.md#1-extraction-backends). ELv2 restricts SaaS redistribution; same Tier-G treatment as documented in ingest.md and [issue #76](https://github.com/qte77/doc-pipeline-engine/issues/76). |
+
+**AWS Strands Agents note** — multiple AWS IDP samples now use Strands Agents as the standard AWS agentic IDP framework (confirmed in sample-aws-idp-pipeline stack above). If an AWS-native orchestration path becomes relevant, Strands Agents is the current AWS reference pattern.
 
 ## 3. Commercial IDP (architecture concept only)
 
@@ -69,20 +74,22 @@ Common traits: vendor lock-in, opaque models, per-page pricing, weak local-only 
 
 What competitors *do not* offer that this project does:
 
-1. **Embeddable engine, not a service.** R2R, AWS IDP, Azure DI, Document AI are services. We ship as a Python library with a CLI; orchestrators (polyforge, office-polyforge, Claude Code plugins) embed us — there is no server to run.
+1. **Embeddable engine, not a service.** R2R, AWS IDP, Azure DI, Document AI are services. We ship as a Python library with a CLI; orchestrators (polyforge, office-polyforge, Claude Code plugins) embed us — there is no server to run. *Strengthened* by R2R maintenance stall (last commit 2025-11-07) — the closest service-shaped competitor has stalled.
 2. **Contracts as the public API.** Every stage validates against a JSON schema. The data plane is orchestration-agnostic — any system that can produce/consume the schemas can participate.
-3. **Strict license isolation.** Apache-2.0 default; AGPL (PyMuPDF) and JVM (Tika, veraPDF) only as opt-in extras. R2R, Unstructured, and the AWS samples are mostly Apache-2.0 too, but none of them publish a license-isolation policy as a first-class architectural commitment.
+3. **Strict license isolation.** Apache-2.0 default; AGPL (PyMuPDF), GPL (marker/surya), ELv2 (Kreuzberg), and JVM (Tika, veraPDF) only as opt-in extras. R2R, Unstructured, and the AWS samples are mostly Apache-2.0/MIT too, but none of them publish a license-isolation policy as a first-class architectural commitment.
 4. **Data-locality policies as a contract dimension.** [§0.5.0](../roadmap.md#050--domain-packs) will declare `local-only` / `claude-api-extracted-only` / `cloud-redacted` profiles that gate which adapters can load. None of the surveyed systems express this as a runtime policy — they assume cloud or assume local, without an enforced switch.
-5. **Domain packs.** [§0.5.0](../roadmap.md#050--domain-packs) plans `mech-elec-cert` and `med-research-patents` packs (prompts, thresholds, formats). Reduces the configuration surface for regulated industries.
-6. **Two-surface split.** Heavy data plane (Python: extract, validate, render) is decoupled from the optional control plane (skills, agents, hooks). The control plane is replaceable; the data plane is not. Most competitors couple the two.
+5. **Domain packs.** [§0.5.0](../roadmap.md#050--domain-packs) plans `mech-elec-cert` and `med-research-patents` packs (prompts, thresholds, formats). *Aspirational until §0.5.0 lands* — no production evidence yet.
+6. **Two-surface split.** Heavy data plane (Python: extract, validate, render) is decoupled from the optional control plane (skills, agents, hooks). The control plane is replaceable; the data plane is not. *Under pressure* — Haystack v2 and LlamaIndex Agentic Document Workflows are coupling control and data planes more tightly, narrowing this differentiator.
 7. **Output-format conformance contract.** `OutputFormat` + `FormatConformance` formalise what "valid output" means per tier. Most pipelines treat output as best-effort rendering; we treat it as a validated contract.
 
 What competitors *do* better (areas to learn from):
 
-- R2R's REST API surface and Postgres-backed observability — if we ever ship a reference deployment.
+- R2R's REST API surface and Postgres-backed observability — if we ever ship a reference deployment. (Note: R2R stalled; architectural patterns still valid.)
 - AWS IDP's SAML/OIDC + private VPC story — relevant once enterprise consumers ask.
 - LlamaIndex's Agentic Document Workflows — informs the P2/P4 orchestration patterns.
 - Unstructured's element-typing taxonomy — useful pre-art when refining the `CanonicalDoc.root` node taxonomy.
+- Knowhere's multi-modal VLM enrichment (table/image summaries linked back to source chunks) + cross-document graph — both go beyond our current `AnalysisReport` shape. Inform [§0.5.0 domain packs](../roadmap.md#050--domain-packs) and any future graph-RAG cross-cut.
+- DocETL's declarative DSL + LLM-optimized operator sequencing — reference for §0.5.0 pipeline configuration surface if we expose a user-facing pipeline definition layer.
 
 ## See also
 

--- a/docs/landscape/ingest.md
+++ b/docs/landscape/ingest.md
@@ -24,13 +24,15 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 
 | Tool | Primary role | License | Runtime | Formats | Verdict |
 | --- | --- | --- | --- | --- | --- |
-| **docling** | Layout-aware PDF/Office → structured doc | MIT | Python + torch | PDF, DOCX, PPTX, HTML, images | **Primary** — best layout fidelity, native target for `CanonicalDoc`. |
+| **docling** | Layout-aware PDF/Office → structured doc; native VLM pipeline (Granite Vision 4.1) added v2.x | MIT | Python + torch | PDF, DOCX, PPTX, HTML, images | **Primary** — best layout fidelity, native target for `CanonicalDoc`. v2.95.0 (2026-05-21), 60k stars. VLM backend partially closes the gap docling stubs (GLM-OCR/PaddleOCR-VL) were designed to fill — reassess those stubs at §0.4.0. |
 | **Kreuzberg** | Async multi-format extraction facade | MIT (≤4.7); ELv2 (≥4.8, Tier G — see [domain-extraction.md license tier reference](domain-extraction.md#license-tier-reference)) | Python (pypdfium2, Tesseract, python-docx, …) | PDF, Office, images, email, HTML | **Primary (breadth)** — covers the long tail with one adapter. See [ADR-0005](../adr/0005-kreuzberg-elv2-license-boundary.md). |
 | **claude_cli_adapter** | LLM-based extraction via Claude Code CLI | n/a (our code) | Claude CLI | Any (LLM-mediated) | **Primary (reference)** — end-to-end wired first; cross-validation baseline. |
 | **GLM-OCR** | Vision-LLM OCR for complex scans | Apache-2.0 | GPU preferred | Images, scanned PDF | Stub adapter — specialized scan/handwriting path. |
-| **PaddleOCR-VL** | Vision-LLM OCR, CJK-strong | Apache-2.0 | GPU preferred | Images, scanned PDF | Stub adapter — non-Latin script fallback. |
+| **PaddleOCR-VL** | Vision-LLM OCR, CJK-strong; PP-OCRv5 + PP-StructureV3 + PP-ChatOCRv4 in v3.0+ | Apache-2.0 | GPU preferred | Images, scanned PDF | **Optional (CJK PDF primary)** — v3.5.0 (2026-05-19), 79k stars. Promoted from stub; PP-OCRv5 is a major VLM upgrade that makes this a direct competitor to docling for CJK PDFs. Gate behind `[paddleocr]` extra; benchmark against docling at §0.4.0. |
 | **Tesseract** | Classical OCR engine | Apache-2.0 | Native C++ binary | Images, scanned PDF | **Transitive** — reached via Kreuzberg/docling; baseline OCR floor, not a direct adapter. |
 | **PyMuPDF (fitz)** | Fast PDF text + layout + images | **AGPL-3.0** (or commercial) | Python + native | PDF | **Optional only** — best-in-class for born-digital PDFs, but AGPL would bleed into consumers. Ship behind an opt-in extra. |
+| **MinerU** (`opendatalab/MinerU`) | Layout-aware PDF/Office → Markdown/JSON; layout-analysis + OCR + table/formula models; strong CJK | **Apache-2.0 + additional terms** (Tier G — see [domain-extraction.md license tier reference](domain-extraction.md#license-tier-reference)): commercial threshold at 100M MAU / USD 20M MRR triggers separate commercial licence; mandatory online-service attribution; auto-termination on non-compliance. GitHub flags as `NOASSERTION`. | Python; GPU strongly preferred (CPU very slow); models ~3-5 GB | PDF, DOCX, PPTX, XLSX | **Opt-in extra (`[mineru]`)** — 64.8 k stars, v3.1.15 (2026-05-19), used by Knowhere as default parser ([e2e-systems.md §2](e2e-systems.md#2-oss-e2e-systems)). Complementary to docling for CJK + complex-layout PDFs. Same Tier-G treatment as Kreuzberg ELv2 ([issue #76](https://github.com/qte77/doc-pipeline-engine/issues/76)): document the thresholds + attribution duty before shipping in any default profile. |
+| **marker** ([repo](https://github.com/datalab-to/marker)) | Layout-aware PDF → Markdown; depends on surya (GPL-3.0) for layout detection | **GPL-3.0** (Tier G — see [domain-extraction.md license tier reference](domain-extraction.md#license-tier-reference)) | Python + torch; GPU preferred | PDF, DOCX, images | **Opt-in (gate)** — v1.10.2 (2026-05), 35k stars. Strong on complex PDFs; GPL-3.0 chains from surya hard dep. Same gate pattern as PyMuPDF: `pip install doc-pipeline-engine[marker]` only; must not appear in default install. |
 | **Apache Tika** | Broad content-extraction server | Apache-2.0 | **JVM** | ~1000+ formats | **Optional (server-mode)** — JVM dep too heavy as default; useful as a remote adapter for enterprise consumers with existing Tika infra. |
 
 ### Notes
@@ -41,6 +43,8 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 
 **PyMuPDF license risk** — AGPL triggers on *distribution* of derived works. Because consumers (polyforge, office-polyforge) embed us, an AGPL hard dep would force them to AGPL as well. Keep it behind `pip install doc-pipeline-engine[pymupdf]` so the choice is explicit and downstream.
 
+**MinerU license risk** — GitHub reports `NOASSERTION`. Reading the LICENSE file directly: Apache-2.0 *plus* a Llama-style commercial threshold (100M MAU OR USD 20M MRR), a mandatory online-service attribution clause, and auto-termination on non-compliance. Same Tier-G treatment as Kreuzberg ELv2. Practical impact: fine for internal and SMB use, but cannot redistribute as plain Apache-2.0 without surfacing the restrictions; cannot run as an unbranded online service. Gate behind `pip install doc-pipeline-engine[mineru]` and document the thresholds + attribution duty in the NOTICE file before any default-profile inclusion.
+
 **Tika cost/benefit** — once you need a JVM, operations teams notice. Ship as a remote-server adapter (`tika.url=...`) rather than an embedded dep, so Java stays out of our install footprint.
 
 ## 2. Source connectors
@@ -50,7 +54,7 @@ Wired behind a `SourceConnector` interface. Emit file lists / blob handles consu
 | Tool | Source system | License | Runtime | Auth | Locality | Verdict |
 | --- | --- | --- | --- | --- | --- | --- |
 | **msgraph-sdk** | SharePoint / OneDrive (MS Graph) | MIT | Python-native | OAuth 2.0 (MSAL / client-credentials) | cloud | **Primary** — official Microsoft SDK; covers SharePoint and OneDrive via single Graph surface. |
-| **O365** | SharePoint / OneDrive (MS Graph) | Apache-2.0 | Python-native | OAuth 2.0 / device flow | cloud | **Optional** — friendlier surface than msgraph-sdk; less actively maintained. |
+| **O365** | SharePoint / OneDrive (MS Graph) | Apache-2.0 | Python-native | OAuth 2.0 / device flow | cloud | **Optional (maintenance concern)** — only 2 releases ever (v2.0 in 2019, v2.1 in 2025-02); commits paused 2026-03-10. Prefer `msgraph-sdk`; use O365 only where its device-flow surface is a hard requirement. |
 | **atlassian-python-api** | Confluence (REST v1/v2) | Apache-2.0 | Python-native | API token / OAuth 2.0 | cloud or on-prem | **Primary** — canonical community SDK; covers Cloud and Server; exposes page-tree traversal. |
 | **google-api-python-client** | Google Drive | Apache-2.0 | Python-native | OAuth 2.0 / service account | cloud | **Primary** — official Google client; stable. |
 | **boto3** | S3 / object storage (AWS, MinIO via `endpoint_url`) | Apache-2.0 | Python-native | IAM / STS / assume-role | cloud or local | **Primary** — de-facto standard; covers S3-compatible stores. |
@@ -74,11 +78,13 @@ Produce the file list that becomes `DiscoveryManifest` (`version`, `source`, `di
 | Tool | Role | License | Runtime | `DiscoveryManifest` fit | Verdict |
 | --- | --- | --- | --- | --- | --- |
 | **polyfetch-scrape** (sibling repo) | Web crawl → URL/file list | Apache-2.0 (internal) | Python-native | Native — already emits structured manifests | **Primary (web)** — purpose-built sibling; reuse output as `DiscoveryManifest` directly. |
-| **trafilatura** | Web content extraction + URL crawl | Apache-2.0 | Python-native | Adapt URL list to `files[]` | **Optional (targeted web)** — lightweight; excellent boilerplate stripping; for single-site crawls where Scrapy overhead is unjustified. |
+| **trafilatura** | Web content extraction + URL crawl | Apache-2.0 | Python-native | Adapt URL list to `files[]` | **Optional (targeted web)** — v2.0.0 (2025-09); breaking change: `bare_extraction()` now returns a `Document` object, not `dict`; `no_fallback` renamed to `fast`. Update any callers before upgrading. 6k stars. |
 | **httpx** | HTTP client for bespoke crawlers | BSD-3-Clause | Python-native | Raw — caller builds manifest | **Building block** — async-native, HTTP/2; recommended base for custom connector fetch loops. |
 | **pathlib** (stdlib) | Local file-tree walk | PSF (stdlib) | Python-native | Direct — `Path.rglob()` → `files[]` | **Primary (local)** — zero dep; the canonical filesystem path. |
-| **watchdog** | Filesystem event watcher | Apache-2.0 | Python-native (optional C ext) | Incremental — emits change events for manifest deltas | **Optional** — for streaming/watch mode; not needed for one-shot batch ingest. |
+| **watchdog** | Filesystem event watcher | Apache-2.0 | Python-native (optional C ext) | Incremental — emits change events for manifest deltas | **Optional** — v6.0.0 (2026-05-07) removed deprecated `echo` utilities; inotify backend now uses `select.poll()`. API-compatible for standard usage but review any `echo`-based code before upgrading from v5. |
 | **scrapy** | Full crawl engine | BSD-3-Clause | Python-native | Adapter needed — Spider yields URLs | **Optional** — justified only for large multi-domain crawls. |
+| **crawl4ai** ([repo](https://github.com/unclecode/crawl4ai)) | LLM-targeted async web crawl with JS rendering | Apache-2.0 | Python-native (Playwright for JS) | URL list to `files[]` via structured extraction | **Optional (JS-heavy sites)** — v0.8.5 (2026-05-25), 66k stars. Complement to trafilatura for SPA/JS-rendered pages where trafilatura's static-HTML path fails. Gate behind `[crawl4ai]` extra (Playwright dep). |
+| **ColPali** ([repo](https://github.com/illuin-tech/colpali)) | VLM page-image retrieval model | MIT | Python + torch; GPU preferred | PDF page images | **Candidate (relevance filter)** — v0.3.16 (2026-05-19), 3k stars. Not an extractor; sits upstream as a relevance-filter layer ahead of extraction for large corpora. Relevant for §0.5.0 domain packs. |
 
 ### Discovery notes
 
@@ -112,6 +118,7 @@ Produce the file list that becomes `DiscoveryManifest` (`version`, `source`, `di
 - PaddleOCR-VL: <https://github.com/PaddlePaddle/PaddleOCR>
 - Tesseract: <https://github.com/tesseract-ocr/tesseract>
 - PyMuPDF: <https://github.com/pymupdf/PyMuPDF>
+- MinerU: <https://github.com/opendatalab/MinerU>
 - Apache Tika: <https://tika.apache.org/>
 
 ### Source connectors
@@ -130,3 +137,7 @@ Produce the file list that becomes `DiscoveryManifest` (`version`, `source`, `di
 - httpx: <https://github.com/encode/httpx>
 - scrapy: <https://github.com/scrapy/scrapy>
 - watchdog: <https://github.com/gorakhargosh/watchdog>
+- crawl4ai: <https://github.com/unclecode/crawl4ai>
+- ColPali: <https://github.com/illuin-tech/colpali>
+- marker: <https://github.com/datalab-to/marker>
+- surya: <https://github.com/datalab-to/surya>

--- a/docs/landscape/output.md
+++ b/docs/landscape/output.md
@@ -2,8 +2,8 @@
 title: Output Landscape
 purpose: Survey of rendering, office formats, templating, and conformance validators for the output stage
 created: 2026-04-26
-updated: 2026-04-26
-validated_links: 2026-04-26
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: landscape
 ---
 
@@ -26,13 +26,13 @@ Output emits documents validating against `OutputFormat` (`id`, `version`, `tier
 
 | Tool | License | Runtime | Output formats | Verdict |
 | --- | --- | --- | --- | --- |
-| **WeasyPrint** | BSD-3-Clause | Python-native | PDF, PNG (from HTML/CSS) | **Primary (PDF)** — pure-Python HTML→PDF; good CSS3 support; no Haskell/Rust install. |
+| **WeasyPrint** ([repo](https://github.com/Kozea/WeasyPrint)) | BSD-3-Clause | Python-native | PDF, PNG (from HTML/CSS) | **Primary (PDF)** — v68.1 (2026-05-25), 9k stars. Pure-Python HTML→PDF; good CSS3 support; no Haskell/Rust install. |
 | **ReportLab** | BSD-3-Clause / commercial (RLPDF) | Python-native | PDF | **Primary (programmatic PDF)** — battle-tested; preferred for data-heavy tables and charts in Comprehensive. |
-| **Typst** | Apache-2.0 | External binary (Rust); `typst` Python binding | PDF, PNG, SVG | **Optional** — modern TeX replacement; Python binding removes shell-out. |
-| **Pandoc** | **GPL-2.0-or-later** | External binary (Haskell) | MD, DOCX, PDF (LaTeX/Typst), HTML, EPUB, LaTeX, RST, … | **Optional** — broadest converter; subprocess use does not impose GPL on the caller, but ship behind `[pandoc]` extra to make the choice explicit. |
-| **Quarto** | MIT (depends on Pandoc internally) | External binary (Deno + Pandoc) | HTML, PDF, DOCX, PPTX, EPUB | **Optional** — best for IMRaD/science reports; heavy install; transitive Pandoc concern. |
-| **Sphinx** | BSD-2-Clause | Python-native (LaTeX for PDF) | HTML, PDF, EPUB, man | **Optional** — autodoc/tech-spec output; heavy for single-doc use. |
-| **mdBook** | MPL-2.0 | External binary (Rust) | HTML book, PDF (via print) | **Optional** — multi-chapter docs sites; MPL-2.0 file-scoped copyleft, acceptable as subprocess. |
+| **Typst** ([repo](https://github.com/typst/typst)) | Apache-2.0 | External binary (Rust); `typst` Python binding | PDF, PNG, SVG | **Optional** — v0.14.2 (2026-05-25), 54k stars. Modern TeX replacement; Python binding removes shell-out. |
+| **Pandoc** ([repo](https://github.com/jgm/pandoc)) | **GPL-2.0-or-later** | External binary (Haskell) | MD, DOCX, PDF (LaTeX/Typst), HTML, EPUB, LaTeX, RST, … | **Optional** — v3.9.0.2 (2026-05), 44k stars. Broadest converter; subprocess use does not impose GPL on the caller, but ship behind `[pandoc]` extra to make the choice explicit. |
+| **Quarto** ([repo](https://github.com/quarto-dev/quarto-cli)) | MIT (COPYING.md; GitHub API returns NOASSERTION) | External binary (Deno + Pandoc) | HTML, PDF, DOCX, PPTX, EPUB | **Optional** — v1.9.38 (2026-05-25), 6k stars. Best for IMRaD/science reports; heavy install; transitive Pandoc concern. |
+| **Sphinx** ([repo](https://github.com/sphinx-doc/sphinx)) | BSD-2-Clause (LICENSE.rst; GitHub API returns NOASSERTION) | Python-native (LaTeX for PDF) | HTML, PDF, EPUB, man | **Optional** — 8k stars. Autodoc/tech-spec output; heavy for single-doc use. |
+| **mdBook** ([repo](https://github.com/rust-lang/mdBook)) | MPL-2.0 | External binary (Rust) | HTML book, PDF (via print) | **Optional** — 22k stars. Multi-chapter docs sites; MPL-2.0 file-scoped copyleft, acceptable as subprocess. |
 
 **Notes** — WeasyPrint + ReportLab cover the two Python-native PDF paths and form the default for Comprehensive PDF. Typst is the cleanest binary path for production-quality PDFs. Pandoc is the Swiss-army-knife behind a license gate.
 
@@ -40,20 +40,20 @@ Output emits documents validating against `OutputFormat` (`id`, `version`, `tier
 
 | Tool | License | Runtime | Formats | Verdict |
 | --- | --- | --- | --- | --- |
-| **python-docx** | MIT | Python-native | DOCX | **Primary** — standard DOCX writer; first-class `CanonicalDoc → DOCX` adapter target. |
-| **docxtpl** | LGPL-2.1 | Python-native (wraps python-docx) | DOCX | **Primary (templates)** — Jinja2-in-DOCX; LGPL is library-use safe for Apache-2.0 callers when not modifying the lib. Confirm with legal before redistributing modified copies. |
-| **python-pptx** | MIT | Python-native | PPTX | **Primary** — only serious Python PPTX writer. |
+| **python-docx** ([repo](https://github.com/python-openxml/python-docx)) | MIT | Python-native | DOCX | **Primary** — 6k stars, last push 2025-06-17. Standard DOCX writer; first-class `CanonicalDoc → DOCX` adapter target. |
+| **docxtpl** ([repo](https://github.com/elapouya/python-docx-template)) | LGPL-2.1 | Python-native (wraps python-docx) | DOCX | **Primary (templates)** — 3k stars, last push 2026-05-18. Jinja2-in-DOCX; LGPL is library-use safe for Apache-2.0 callers when not modifying the lib. Confirm with legal before redistributing modified copies. |
+| **python-pptx** ([repo](https://github.com/scanny/python-pptx)) | MIT | Python-native | PPTX | **Primary** — 3k stars, last push 2024-08-07. Only serious Python PPTX writer. |
 | **openpyxl** | MIT | Python-native | XLSX (read+write) | **Primary** — standard XLSX writer; required for tabular outputs. |
-| **xlsxwriter** | BSD-2-Clause | Python-native | XLSX (write only) | **Secondary** — richer chart/formatting API; use when output requires complex Excel charts. |
-| **odfpy** | Apache-2.0 / LGPL-2.1 (dual) | Python-native | ODS, ODT, ODP | **Optional** — ODF rarely required by primary consumers. |
+| **xlsxwriter** ([repo](https://github.com/jmcnamara/XlsxWriter)) | BSD-2-Clause | Python-native | XLSX (write only) | **Secondary** — 4k stars, last push 2026-03-22. Richer chart/formatting API; use when output requires complex Excel charts. |
+| **odfpy** ([repo](https://github.com/eea/odfpy)) | Apache-2.0 / GPL-2.0 (dual; LICENSE files confirm both — API reports NOASSERTION) | Python-native | ODS, ODT, ODP | **Optional** — 357 stars, last push 2026-04-07. ODF rarely required by primary consumers. Note: prior entry listed LGPL-2.1 incorrectly; repo contains `APACHE-LICENSE-2.0.txt` and `GPL-LICENSE-2.txt`. |
 
 ## 3. Templating engines
 
 | Tool | License | Runtime | Use case | Verdict |
 | --- | --- | --- | --- | --- |
-| **Jinja2** | BSD-3-Clause | Python-native | HTML, MD, LaTeX, Typst text templates | **Primary** — de-facto standard; covers Quick and Comprehensive text templates. |
+| **Jinja2** ([repo](https://github.com/pallets/jinja)) | BSD-3-Clause | Python-native | HTML, MD, LaTeX, Typst text templates | **Primary** — v3.1.6 (2025-06-14), 11k stars. De-facto standard; covers Quick and Comprehensive text templates. |
 | **pystache** | MIT | Python-native | Mustache logic-less templates | **Optional** — pick where logic-less is required for cross-language template sharing. |
-| **chevron** | MIT | Python-native | Mustache | **Avoid** — unmaintained since 2021; prefer pystache. |
+| **chevron** | MIT | Python-native | Mustache | **Avoid** — last push 2023-08-24, no releases; prefer pystache. |
 | **mjml-python** | MIT | Python-native (transpiler port) | Responsive HTML email | **Optional** — gate behind `[email]` extra. |
 
 **Notes** — Jinja2 is the only must-have. Pick one Mustache impl (pystache) if needed; don't ship both.
@@ -66,12 +66,12 @@ Backs the `FormatConformance` contract. Practical pattern: rely on writer librar
 | --- | --- | --- | --- | --- |
 | **python-docx structural check** | MIT | Python-native | DOCX (OOXML constructor raises on malformed) | **Runtime** — pair with `lxml` schema validation for deeper checks. |
 | **WeasyPrint runtime errors** | BSD-3-Clause | Python-native | HTML/CSS for PDF rendering | **Runtime** — raises on unrenderable input. |
-| **pymarkdownlnt** | MIT | Python-native | CommonMark / GFM Markdown | **Runtime** — backs Quick-tier Markdown conformance. |
-| **markdownlint-cli2** | MIT | Node.js | Markdown | **CI gate** — richer ruleset; only if Node already present. |
-| **veraPDF** | GPL-3.0 + MPL-2.0 (dual) | **JVM** | PDF/A-1b/2b/3b/u, PDF/UA | **Optional / CI-only** — best PDF/A validator; JVM dep. Gate behind `[pdf-a]` or run only in CI. |
+| **pymarkdownlnt** ([repo](https://github.com/jackdewinter/pymarkdown)) | MIT | Python-native | CommonMark / GFM Markdown | **Runtime** — v0.9.37 (2026-05-19), 136 stars. Backs Quick-tier Markdown conformance. |
+| **markdownlint-cli2** ([repo](https://github.com/DavidAnson/markdownlint-cli2)) | MIT | Node.js | Markdown | **CI gate** — 815 stars, last push 2026-05-21. Richer ruleset; only if Node already present. |
+| **veraPDF** ([repo](https://github.com/veraPDF/veraPDF-library)) | GPL-3.0 + MPL-2.0 (dual) | **JVM** | PDF/A-1b/2b/3b/u, PDF/UA | **Optional / CI-only** — v1.30.1 (2026-05-19), 330 stars. Best PDF/A validator; JVM dep. Gate behind `[pdf-a]` or run only in CI. |
 | **vnu (Nu HTML Checker)** | MIT | **JVM** | HTML5 | **Optional / CI-only** — same opt-in pattern as veraPDF. |
-| **htmlhint** | MIT | Node.js | HTML lint | **CI gate** — lighter than vnu. |
-| **mammoth** (read-side) | BSD-2-Clause | Python-native | DOCX semantic round-trip | **Optional** — semantic-issue signal, not strict schema validation. |
+| **htmlhint** ([repo](https://github.com/HTMLHint/HTMLHint)) | MIT | Node.js | HTML lint | **CI gate** — 3k stars, last push 2026-05-21. Lighter than vnu. |
+| **mammoth** ([repo](https://github.com/mwilliamson/python-mammoth)) (read-side) | BSD-2-Clause | Python-native | DOCX semantic round-trip | **Optional** — 1k stars, last push 2026-05-24. Semantic-issue signal, not strict schema validation. |
 
 **Notes** — There is no Python-native PDF/A validator. veraPDF (JVM) is the only production-grade option; don't embed in the runtime hot path.
 

--- a/docs/landscape/process.md
+++ b/docs/landscape/process.md
@@ -2,8 +2,8 @@
 title: Process Landscape
 purpose: Survey of chunking, table/figure extraction, NER, RAG indexing, schema-templated extraction, and CanonicalDoc normalization for the process stage
 created: 2026-04-26
-updated: 2026-05-21
-validated_links: 2026-05-21
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: landscape
 ---
 
@@ -27,9 +27,11 @@ Survey of candidates for the **process** stage — chunking, supplemental table/
 | **llama-index-core** node parsers | Semantic, layout-aware, sentence-window, hierarchical | MIT | Python; some pull sentence-transformers (GPU optional) | local | **Candidate** — `HierarchicalNodeParser` mirrors tier hierarchy; evaluate footprint. |
 | **semantic-chunker** | Embedding-similarity boundary detection | MIT | Python + sentence-transformers (~300 MB) | local | **Optional (Comprehensive)** — improves coherence; gate behind `[semantic]` extra. |
 | **unstructured** chunking | Layout/title-aware, element-boundary | Apache-2.0 | Python; optional native deps | local | **Transitive** — only when unstructured produced the elements. |
+| **adaptive-chunking** (`ekimetrics/adaptive-chunking`) | Per-document method selection via 5 intrinsic quality metrics (size compliance, intrachunk cohesion, contextual coherence, block integrity, missing-reference error); ships 4 default splitters (recursive ×2, page, LLM-regex); pluggable | MIT (core); `[coref]` extra is CC-BY-NC-SA-4.0, `[parsing]` extra is AGPL-3.0 | Python + spaCy; Docling default parser; optional Jina embeddings | local (core) | **Candidate (Comprehensive)** — LREC 2026 paper (arXiv 2603.25333); 67.7 retrieval completeness vs 58.1 langchain-recursive on 33-doc CLAIR corpus (Wilcoxon p < 0.05). Core MIT is drop-in; gate `[coref]` and `[parsing]` extras. Metrics layer doubles as ground-truth-free chunk eval — cross-ref for [§0.6.0 eval](../roadmap.md#060--eval). |
+| **chonkie** ([repo](https://github.com/chonkie-inc/chonkie)) | Chunking library with late-chunking support; token-aware, semantic, and late-interaction modes | MIT | Python + sentence-transformers (optional) | local | **Candidate** — v1.6.7 (2026-05-20), 4k stars. Late-chunking (ColBERT-style) improves dense retrieval for long documents. Gate behind `[semantic]` extra; evaluate against semantic-chunker at §0.4.0. |
 | **custom layout-aware** | Tier-split over `CanonicalDoc.root` | n/a (our code) | Python, CPU | local | **Primary** — first-class path; the canonical tree already encodes hierarchy. |
 
-**Notes** — For Quick tier, walking the heading tree replaces external chunkers. External chunkers matter for the Comprehensive RAG-index path.
+**Notes** — For Quick tier, walking the heading tree replaces external chunkers. External chunkers matter for the Comprehensive RAG-index path. `adaptive-chunking` is the academic-validated picker on top of the rest; its 5 intrinsic metrics are reusable independently of which splitter wins per doc.
 
 ## 2. Table / figure extraction (supplemental)
 
@@ -38,23 +40,24 @@ When extraction backends (docling, Kreuzberg) miss or mangle tables/figures.
 | Tool | Role | License | Runtime | Locality | Verdict |
 | --- | --- | --- | --- | --- | --- |
 | **pdfplumber** | Text + tables + bbox from PDFs | MIT | Python + pdfminer.six | local | **Primary (light fallback)** — no native deps beyond pdfminer; lower recall than Camelot but easy default. |
-| **Camelot** | Lattice + stream table extraction from PDFs | MIT | Python + Ghostscript + OpenCV | local | **Optional** — best lattice recall on born-digital PDFs; Ghostscript native dep. |
+| **Camelot** ([repo](https://github.com/camelot-dev/camelot)) | Lattice + stream table extraction from PDFs | MIT | Python + Ghostscript + OpenCV | local | **Optional** — best lattice recall on born-digital PDFs; Ghostscript native dep. v2.0.0rc1 (2026-05-25, RC stage); active fork at `camelot-dev/camelot` (3.7k stars, last push 2026-05-25). The `atlanhq/camelot-py` fork (NOASSERTION licence, dormant 2023-01-05) is a dead end — do not use. Pin to `camelot-dev/camelot` only. |
 | **img2table** | Heuristic table extraction from images and PDFs | Apache-2.0 | Python + OpenCV | local | **Optional** — CPU-only fallback for image/scan paths without GPU. |
-| **table-transformer (TATR)** | DETR-based table detection + structure recognition | MIT | Python + torch (~1–2 GB) | local (GPU preferred) | **Optional (Comprehensive)** — Microsoft TATR; gate behind `[table-gpu]`. |
+| **table-transformer (TATR)** ([repo](https://github.com/microsoft/table-transformer)) | DETR-based table detection + structure recognition | MIT | Python + torch (~1–2 GB) | local (GPU preferred) | **Optional (Comprehensive)** — Microsoft TATR; gate behind `[table-gpu]`. Last push 2024-06-24; last release v1.0.0 (2023). Microsoft repo dormant; HuggingFace weights stable. Do not expect upstream fixes. |
+| **marker** ([repo](https://github.com/datalab-to/marker)) | Layout-aware PDF → Markdown with table/figure extraction; hard-deps **surya** ([repo](https://github.com/datalab-to/surya)) for layout detection | **GPL-3.0** (Tier G — see [domain-extraction.md license tier reference](domain-extraction.md#license-tier-reference)) | Python + torch; GPU preferred | PDF, images | **Opt-in (gate)** — marker v1.10.2 (2026-05), 35k stars; surya v0.17.1 (2026-05), 20k stars. Both GPL-3.0. Do not include in default install; gate behind `[marker]` extra. |
 
-**Notes** — Priority: pdfplumber as default → Camelot for lattice precision → img2table for CPU image paths → table-transformer for full Comprehensive accuracy. None overlap with docling/Kreuzberg's primary role; they are remediation layers.
+**Notes** — Priority: pdfplumber as default → Camelot for lattice precision → img2table for CPU image paths → table-transformer for full Comprehensive accuracy → marker/surya as opt-in-only. None overlap with docling/Kreuzberg's primary role; they are remediation layers.
 
 ## 3. Entity extraction / NER
 
 | Tool | Approach | License | Runtime | Locality | Verdict |
 | --- | --- | --- | --- | --- | --- |
 | **spaCy** | Rule + statistical NER, 50+ language models | MIT | Python; models 12–560 MB | local | **Primary** — deterministic, fast, no GPU for `en_core_web_sm/md`. |
-| **GLiNER** | Generative LM-based zero-shot NER | Apache-2.0 | Python + torch (~500 MB) | local | **Candidate (Comprehensive)** — domain-specific entities without retraining; gate behind `[ner-gliner]`. |
-| **Flair** | Contextual string embeddings NER | MIT | Python + torch (300 MB–1 GB) | local | **Optional** — strong on CoNLL; redundant if GLiNER adopted. |
-| **outlines** | Constrained LLM decoding for structured NER | Apache-2.0 | Python + torch + local LLM | local (with local model) | **Candidate (local-LLM)** — pairs with Ollama/vLLM; no cloud calls. |
-| **instructor** | Structured output via LLM function-calling | MIT | Python; OpenAI-compatible API | **cloud by default** | **Opt-in only** — violates `local-only` policy unless pointed at local vLLM. Gate behind `[ner-llm]` and require explicit endpoint config. |
+| **GLiNER** ([repo](https://github.com/urchade/GLiNER)) | Generative LM-based zero-shot NER | Apache-2.0 | Python + torch (~500 MB) | local | **Candidate (Comprehensive)** — v0.2.26 (2026-05-13), 3k stars. Domain-specific entities without retraining; gate behind `[ner-gliner]`. Siblings: **GLiREL** ([repo](https://github.com/jackboyla/GLiREL)) for zero-shot relation extraction (MIT, v1.2.1, 274 stars); **gliner-multitask** model (HuggingFace: `knowledgator/gliner-multitask-large-v0.5`) for NER + RE + classification in one pass — no separate repo, load via GLiNER library. |
+| **Flair** | Contextual string embeddings NER | MIT | Python + torch (300 MB–1 GB) | local | **Avoid** — last release v0.15.1 (2025-10-27), last push 2025-10-27, 14k stars. Superseded by the GLiNER family for this pipeline's zero-shot use case. Drop if GLiNER is adopted; keep only for supervised CoNLL-style models not covered by GLiNER. |
+| **outlines** ([repo](https://github.com/dottxt-ai/outlines)) / **outlines-core** ([repo](https://github.com/dottxt-ai/outlines-core)) | Constrained LLM decoding for structured NER | Apache-2.0 | Python + torch + local LLM | local (with local model) | **Candidate (local-LLM)** — core runtime split into `outlines-core` (Apache-2.0, v0.2.14, 291 stars); `outlines` v1.3.0 remains the user-facing package. Pairs with Ollama/vLLM; no cloud calls. |
+| **instructor** ([repo](https://github.com/567-labs/instructor)) | Structured output via LLM function-calling | MIT | Python; OpenAI-compatible API | **cloud by default** (local with Ollama/litellm) | **Opt-in only** — v1.15.1 (2026-04-03), 13k stars. v1.x added native `ollama` and `litellm` backends — pointing at local vLLM/Ollama makes this local-compliant. Still gate behind `[ner-llm]` and require explicit endpoint config; default remains cloud. |
 
-**Notes** — Data-locality is the critical axis. spaCy is the safe default. instructor/outlines are the precision ceiling; both require explicit opt-in. Cloud NER calls must be refused under [§0.5.0](../roadmap.md#050--domain-packs) `local-only` profile.
+**Notes** — Data-locality is the critical axis. spaCy is the safe default. instructor/outlines are the precision ceiling; both require explicit opt-in. Cloud NER calls must be refused under [§0.5.0](../roadmap.md#050--domain-packs) `local-only` profile. instructor v1.x with Ollama/litellm can satisfy `local-only` if endpoint is explicitly set; still requires opt-in gate.
 
 ## 4. RAG indexing
 
@@ -63,17 +66,20 @@ Framework vs vector store are orthogonal. Recommended default: LlamaIndex (frame
 | Tool | Role | License | Runtime | Locality | Verdict |
 | --- | --- | --- | --- | --- | --- |
 | **llama-index-core** | RAG framework + ingestion pipeline | MIT | Python | local (LLM calls configurable) | **Primary (framework)** — `VectorStoreIndex` wraps any store. |
-| **Haystack (haystack-ai)** | RAG pipeline orchestration | Apache-2.0 | Python | local | **Alternative** — deeper graph; prefer LlamaIndex unless consumer already uses Haystack. |
-| **Chroma (chromadb)** | Embedded vector store | Apache-2.0 | Python; optional native HNSW | local | **Primary (store)** — zero-server, embedded, no Docker. |
+| **Haystack (haystack-ai)** ([repo](https://github.com/deepset-ai/haystack)) | RAG pipeline orchestration | Apache-2.0 | Python | local | **Alternative** — v2.29.0 (2026-05-25), 25k stars. v2 is the current API; v1 deprecated upstream. Deeper pipeline graph; prefer LlamaIndex unless consumer already uses Haystack. |
+| **Chroma (chromadb)** ([repo](https://github.com/chroma-core/chroma)) | Embedded vector store | Apache-2.0 | Python; optional native HNSW | local | **Primary (store)** — v1.5.9 (2026-05-05), 28k stars. Zero-server, embedded, no Docker. v0.5+ added native BM25 + vector hybrid search — reduces the gap that txtai was filling; reassess txtai candidacy. |
 | **Qdrant client** | Client for Qdrant server | Apache-2.0 | Python; needs server or cloud | local server or cloud | **Optional** — better multi-tenant story; overkill for embedded default. |
 | **FAISS** | Flat + ANN index | MIT | Python + native (~50 MB CPU) | local | **Candidate** — fastest CPU ANN; less ergonomic than Chroma for metadata filtering. |
-| **txtai** | All-in-one embeddings + index + RAG | Apache-2.0 | Python + sentence-transformers | local | **Candidate (light)** — lower integration surface than LlamaIndex. |
+| **txtai** | All-in-one embeddings + index + RAG | Apache-2.0 | Python + sentence-transformers | local | **Candidate (light)** — lower integration surface than LlamaIndex. Candidacy weakened by Chroma v0.5+ native BM25 hybrid search. |
+| **LightRAG** ([repo](https://github.com/HKUDS/LightRAG)) | Graph-augmented RAG with KG construction | MIT | Python + torch + local/cloud LLM | local (LLM calls configurable) | **Candidate (graph-RAG)** — v1.5.0rc2 (2026-05-25), 36k stars. Pairs vector + graph retrieval; builds entity KG from documents. Evaluate alongside LlamaIndex for §0.5.0 cross-doc graph use cases. |
+| **nano-graphrag** ([repo](https://github.com/gusye1234/nano-graphrag)) | Lightweight GraphRAG reference impl | MIT | Python | local | **Candidate (light graph-RAG)** — v0.0.8 (2026-01-27), 4k stars. Simpler alternative to LightRAG for single-domain graph use. |
 
 ## 5. Normalization to CanonicalDoc
 
 | Source / tool | What it provides | Gap vs `CanonicalDoc` | License | Verdict |
 | --- | --- | --- | --- | --- |
-| **docling `DoclingDocument`** | Hierarchical doc tree with headings, tables, figures, text blocks; JSON-serializable | Missing `source_sha256`, `built_at`, `tier_summary`; table/figure refs need mapping to `root` leaves | MIT | **Primary normalization source** — richest structural fidelity; thin adapter adds provenance + tier split. |
+| **docling `DoclingDocument`** ([repo](https://github.com/docling-project/docling)) | Hierarchical doc tree with headings, tables, figures, text blocks; JSON-serializable | Missing `source_sha256`, `built_at`, `tier_summary`; table/figure refs need mapping to `root` leaves | MIT | **Primary normalization source** — richest structural fidelity; thin adapter adds provenance + tier split. v2 changed table/figure serialization mid-2025; review `v2_normalize` adapter and test fixtures against v2.95.0 schema before next release. |
+| **docling-core** ([repo](https://github.com/docling-project/docling-core)) | Schema-only sub-package (types, validators, serializers for `DoclingDocument`) split from docling main; Python-native, no torch | No extraction logic; pair with docling for actual normalization | MIT | **Candidate (light import)** — v2.77.0 (2026-05-19), 255 stars. Lighter import for adapters that only need the type definitions without pulling torch; avoids transitive torch dependency at import time in process-stage adapters. |
 | **unstructured element schema** | Flat list of typed elements (Title, NarrativeText, Table, Image, …) | No hierarchy; reconstruct from sequence; no provenance | Apache-2.0 | **Secondary** — reconstruct `root` via heading-indent heuristic. Lossier than docling. |
 | **Pandoc AST** (via `pypandoc`) | Universal AST; 40+ formats | Pandoc binary GPL; AST is Haskell-native JSON; no provenance | GPL-2+ (Pandoc); MIT (`pypandoc`) | **Optional** — for Office/Markdown/RST sources docling handles poorly. Pandoc binary called as subprocess (does not link), but document the GPL gate. |
 | **custom normalizer (in-house)** | Adapter per backend → `CanonicalDoc`; provenance, sha256, tier split baked in | n/a — we own the schema | n/a (our code) | **Required** — load-bearing contract enforcer regardless of upstream source. |
@@ -96,7 +102,7 @@ Given a JSON schema template, return JSON conforming to that template. Distinct 
 
 NuExtract3 is a vision-language model — it can read PDFs as images directly, so it overlaps slightly with `Extract` for born-digital and scanned PDFs. The recommended pipeline position is still **downstream of Kreuzberg** (Kreuzberg supplies text+layout; NuExtract3 maps text → schema), but a text-skipping VLM mode is available for scans where Kreuzberg / Tesseract struggle.
 
-Self-reported benchmarks (NuMind, ~600-doc internal set): NuExtract3 at 0.651 vs Qwen3.5-9B at 0.479 and Qwen3.5-4B at 0.417 — outperforms general LLMs ~2× its size on schema-compliance. No independent third-party replication yet.
+Self-reported benchmarks (NuMind, ~600-doc internal set): NuExtract3 at 0.651 vs Qwen3.5-9B at 0.479 and Qwen3.5-4B at 0.417 — outperforms general LLMs ~2× its size on schema-compliance. No independent third-party replication as of 2026-05-25; treat NuMind's published numbers as directional only until an external benchmark confirms them. Promotion to in-process leg should wait for the `external/nuextract/run_oneshot.py` benchmark results.
 
 ## What "canonical" means concretely
 
@@ -126,6 +132,7 @@ Three load-bearing claims a `CanonicalDoc` makes that downstream stages rely on:
 - llama-index node parsers: <https://github.com/run-llama/llama_index>
 - semantic-chunker: <https://pypi.org/project/semantic-chunker/>
 - unstructured: <https://github.com/Unstructured-IO/unstructured>
+- chonkie: <https://github.com/chonkie-inc/chonkie>
 
 ### Tables / figures
 
@@ -133,13 +140,17 @@ Three load-bearing claims a `CanonicalDoc` makes that downstream stages rely on:
 - Camelot: <https://github.com/camelot-dev/camelot>
 - img2table: <https://github.com/xavctn/img2table>
 - table-transformer: <https://github.com/microsoft/table-transformer>
+- marker: <https://github.com/datalab-to/marker>
+- surya: <https://github.com/datalab-to/surya>
 
 ### NER
 
 - spaCy: <https://github.com/explosion/spaCy>
 - GLiNER: <https://github.com/urchade/GLiNER>
+- GLiREL: <https://github.com/jackboyla/GLiREL>
 - Flair: <https://github.com/flairNLP/flair>
 - outlines: <https://github.com/dottxt-ai/outlines>
+- outlines-core: <https://github.com/dottxt-ai/outlines-core>
 - instructor: <https://github.com/567-labs/instructor>
 
 ### RAG indexing
@@ -150,10 +161,13 @@ Three load-bearing claims a `CanonicalDoc` makes that downstream stages rely on:
 - Qdrant client: <https://github.com/qdrant/qdrant-client>
 - FAISS: <https://github.com/facebookresearch/faiss>
 - txtai: <https://github.com/neuml/txtai>
+- LightRAG: <https://github.com/HKUDS/LightRAG>
+- nano-graphrag: <https://github.com/gusye1234/nano-graphrag>
 
 ### Normalization
 
 - docling: <https://github.com/docling-project/docling>
+- docling-core: <https://github.com/docling-project/docling-core>
 - pypandoc: <https://github.com/JessicaTegner/pypandoc>
 
 ### Schema-templated extraction


### PR DESCRIPTION
## Summary

Landscape audit cycle 2026-05-25. Carves a slice off #77 and adds three new candidates surfaced during the conversation.

**New candidates added** (the original ask):

- `process.md §1` — **adaptive-chunking** (ekimetrics, MIT, LREC 2026 paper): per-document method selection via 5 intrinsic quality metrics. Metrics layer doubles as ground-truth-free chunk eval — cross-ref §0.6.0.
- `e2e-systems.md §2` — **Ontos-AI/Knowhere** (Apache-2.0): closest competitor parallel to R2R; deployed-service architecture; multi-modal VLM enrichment + cross-doc graph go beyond our roadmap.
- `ingest.md §1` — **MinerU** (opendatalab): **Tier-G licence** — Apache-2.0 + commercial threshold (100M MAU / USD 20M MRR) + mandatory online-service attribution + auto-termination. GitHub flags `NOASSERTION`. Same gate pattern as Kreuzberg ELv2 (#76). Gated to `[mineru]` extra; documented in NOTICE prerequisite.

**Applied #77 audit menu** across all four landscape files:

- `ingest.md` — docling VLM note (Granite Vision 4.1, v2.95.0); PaddleOCR-VL promoted to Optional (CJK PDF primary); +crawl4ai, +ColPali, +marker (GPL-3.0 gate); trafilatura v2 / watchdog v6 / O365 maintenance notes.
- `process.md` — +chonkie (late-chunking), +LightRAG, +nano-graphrag, +docling-core, +marker/surya (GPL gate); Flair demoted to Avoid; GLiNER expanded with GLiREL + gliner-multitask; Camelot fork pin (camelot-dev only); table-transformer dormant flag; docling v2 schema-change warning; NuExtract3 caveat strengthened; instructor v1.x local-backend note; Chroma v0.5 BM25 note; outlines/outlines-core split note.
- `output.md` — full GitHub-API-verified audit (original sweep was network-blocked); odfpy licence corrected (Apache-2.0 + GPL-2.0 dual, not LGPL-2.1); Quarto/Sphinx licences confirmed by direct LICENSE-file reads.
- `e2e-systems.md` — R2R licence Apache→MIT + maintenance stall; AWS GenAI IDP Apache→MIT-0; sample-aws-idp-pipeline corrected to Amazon Software License (proprietary); +Kreuzberg system-level entry; +DocETL; +Strands Agents ref-arch; LlamaIndex rebrand qualifier; thetanishqrathore expanded; dropped dormant aws-samples regulated-industries; gap-analysis claims 1/5/6 updated.

**Verification surprises** worth follow-up issues:

- `odfpy` licence in our doc was wrong (was Apache-2.0/LGPL-2.1; actually Apache-2.0 + GPL-2.0 dual). Treat as GPL-2.0 for distribution.
- `sample-aws-idp-pipeline` uses Amazon Software License (proprietary) — cannot redistribute or import.
- `GLiREL` has no licence declared in-repo — confirm before any integration.
- `MinerU` licence is NOT plain Apache-2.0 (Issue #77 currently states it is) — see correction comment on #77.

## Test plan

- [ ] Markdownlint passes (`make lint-md` or equivalent).
- [ ] All inline links resolve (validated links date bumped to 2026-05-25).
- [ ] No broken cross-refs to `domain-extraction.md#license-tier-reference` (Tier G).
- [ ] Frontmatter `updated` and `validated_links` are 2026-05-25 on all four files.

Refs #77

Generated with Claude <noreply@anthropic.com>