### PR TITLE
docs(adr): MADR 3.x retrofit + ADR-0005 (Kreuzberg ELv2) + index

### DIFF
--- a/.claude/rules/frontmatter-convention.md
+++ b/.claude/rules/frontmatter-convention.md
@@ -76,3 +76,15 @@ false MD041 (first-line-heading) and MD003 (heading-style) errors.
 
 - No `sources:` key in frontmatter — sources go in the Sources section at end of file
 - Sources section uses reference-style links (`[key]: url` at bottom)
+
+## ADR Exception (MADR 3.x)
+
+Files under `docs/adr/` follow [MADR 3.x](https://adr.github.io/madr/) and
+diverge from the rules above:
+
+- The Sources section is named **`## More Information`** (MADR 3.x canonical
+  field), not `## Sources`.
+- The bare-URL format `- name: <url>` is the established ADR precedent and
+  is preserved (reference-style links are not required for ADRs).
+- All other frontmatter rules (required fields, line-1 frontmatter, no HTML
+  comments above `---`) still apply.

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,9 +6,7 @@
     // Line length: disabled globally (per the frontmatter-convention rule import).
     "MD013": false,
     // First-line H1 satisfied by YAML frontmatter `title:` field.
-    "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" },
-    // ADRs use bold **Pros** / **Cons** labels inside option subsections — intentional, not headings.
-    "MD036": false
+    "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" }
   },
   "globs": [
     "**/*.md"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,7 +6,9 @@
     // Line length: disabled globally (per the frontmatter-convention rule import).
     "MD013": false,
     // First-line H1 satisfied by YAML frontmatter `title:` field.
-    "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" }
+    "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" },
+    // ADRs use bold **Pros** / **Cons** labels inside option subsections — intentional, not headings.
+    "MD036": false
   },
   "globs": [
     "**/*.md"

--- a/docs/adr/0001-pydantic-as-contract-source-of-truth.md
+++ b/docs/adr/0001-pydantic-as-contract-source-of-truth.md
@@ -2,14 +2,16 @@
 title: ADR-0001 — Pydantic as the contract source of truth
 purpose: Records the decision to delete contracts/*.schema.json and make Pydantic v2 models the single source of truth for stage contracts
 created: 2026-04-27
-updated: 2026-04-27
-validated_links: 2026-04-27
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: technical
 ---
 
-**Status**: Accepted (2026-04-27)
+## Status
 
-## Context
+Accepted — 2026-04-27
+
+## Context and Problem Statement
 
 §0.1.0 shipped 10 JSON Schema files under `contracts/` as the
 load-bearing interface between every pipeline stage, validated at gate
@@ -29,9 +31,65 @@ Three pressures pushed for a typed-model layer:
    Python type layer would mean every contract change had to
    touch both, with CI required to detect drift.
 
-## Decision
+## Decision Drivers
 
-**Pydantic v2 models are the single source of truth.** The 10 files
+- Editor support / refactoring safety: `dict[str, Any]` gives no field completion or rename signals
+- mkdocs API rendering: Pydantic models with `Field(description=...)` render natively; JSON Schema files do not
+- Two sources of truth: JSON Schema + Python type layer requires dual maintenance and CI drift detection
+
+## Considered Options
+
+### Option 1 — Pydantic v2 models as single source of truth
+
+**Pros**
+
+- Field completion, type-checking, and rename signals available in editors
+- Pydantic models with `Field(description=...)` render natively in mkdocstrings
+- Single point of change for every contract; no drift between schema and code
+- Expressive validators (`@field_validator`, `@model_validator`) available
+
+**Cons**
+
+- §0.1.0 wire format is no longer pinned to a hand-written file; field changes are visible only in the model diff
+- Downstream consumers that previously read `contracts/*.schema.json` via path must switch to importing the model or shelling out to the CLI dump command
+
+### Option 2 — Keep JSON Schemas authoritative; codegen Pydantic stubs from them
+
+**Pros**
+
+- Wire format remains explicitly declared in hand-written schema files
+- Existing JSON Schema tooling and consumers keep working unchanged
+
+**Cons**
+
+- Loses Pydantic's expressive validators (`@field_validator`, `@model_validator`)
+- Adds a codegen step on every contract change
+- Leaves the wire format frozen at whatever the schema said — including its inconsistencies
+
+### Option 3 — Hybrid: both authoritative
+
+**Pros**
+
+- Retains JSON Schema as an explicit contract artifact alongside typed Python models
+
+**Cons**
+
+- Divergence risk; CI drift checks become load-bearing
+
+### Option 4 — Keep both authoritative; regenerate JSON in CI from models
+
+**Pros**
+
+- On-disk JSON Schema files remain available for external tooling and IDE/GitHub blob view
+
+**Cons**
+
+- Extra build step with no consumer benefit once a CLI dump exposes the schema
+- On-disk files would still get stale reads in IDEs / GitHub blob view
+
+## Decision Outcome
+
+Chosen: **Option 1 — Pydantic v2 models as single source of truth**. The 10 files
 under `contracts/` are deleted; their content is reproduced as
 Pydantic `BaseModel` definitions under
 `src/doc_pipeline_engine/models/`, one file per contract.
@@ -49,21 +107,6 @@ The gate API in `base/contracts.py` keeps its public shape
 Internally both dispatch into `Model.model_validate(...)` and raise a
 new `ContractValidationError` (with a `.message` attribute matching
 the old `jsonschema.ValidationError` shape that `runner.run` reads).
-
-## Rejected alternatives
-
-- **Keep JSON Schemas authoritative; codegen Pydantic stubs from
-  them** (e.g. via `datamodel-code-generator`). Rejected: loses
-  Pydantic's expressive validators (`@field_validator`,
-  `@model_validator`), adds a codegen step on every contract change,
-  and leaves the wire format frozen at whatever the schema said —
-  including its inconsistencies.
-- **Hybrid (both authoritative)**. Rejected: divergence risk; CI
-  drift checks become load-bearing.
-- **Keep both authoritative; regenerate JSON in CI from models.**
-  Rejected: extra build step, no consumer benefit once a CLI dump
-  exposes the schema, and the on-disk files would still get stale
-  reads in IDEs / GitHub blob view.
 
 ## Consequences
 
@@ -89,7 +132,7 @@ the old `jsonschema.ValidationError` shape that `runner.run` reads).
   `.claude/rules/core-principles.md` warned against doing both at
   once.
 
-## Sources
+## More Information
 
 - Pydantic v2 docs: <https://docs.pydantic.dev/latest/>
 - mkdocstrings Pydantic rendering: <https://mkdocstrings.github.io/python/usage/configuration/general/>

--- a/docs/adr/0001-pydantic-as-contract-source-of-truth.md
+++ b/docs/adr/0001-pydantic-as-contract-source-of-truth.md
@@ -41,51 +41,31 @@ Three pressures pushed for a typed-model layer:
 
 ### Option 1 — Pydantic v2 models as single source of truth
 
-**Pros**
-
-- Field completion, type-checking, and rename signals available in editors
-- Pydantic models with `Field(description=...)` render natively in mkdocstrings
-- Single point of change for every contract; no drift between schema and code
-- Expressive validators (`@field_validator`, `@model_validator`) available
-
-**Cons**
-
-- §0.1.0 wire format is no longer pinned to a hand-written file; field changes are visible only in the model diff
-- Downstream consumers that previously read `contracts/*.schema.json` via path must switch to importing the model or shelling out to the CLI dump command
+- Good, because field completion, type-checking, and rename signals available in editors
+- Good, because Pydantic models with `Field(description=...)` render natively in mkdocstrings
+- Good, because single point of change for every contract; no drift between schema and code
+- Good, because expressive validators (`@field_validator`, `@model_validator`) available
+- Bad, because §0.1.0 wire format is no longer pinned to a hand-written file; field changes are visible only in the model diff
+- Bad, because downstream consumers that previously read `contracts/*.schema.json` via path must switch to importing the model or shelling out to the CLI dump command
 
 ### Option 2 — Keep JSON Schemas authoritative; codegen Pydantic stubs from them
 
-**Pros**
-
-- Wire format remains explicitly declared in hand-written schema files
-- Existing JSON Schema tooling and consumers keep working unchanged
-
-**Cons**
-
-- Loses Pydantic's expressive validators (`@field_validator`, `@model_validator`)
-- Adds a codegen step on every contract change
-- Leaves the wire format frozen at whatever the schema said — including its inconsistencies
+- Good, because wire format remains explicitly declared in hand-written schema files
+- Good, because existing JSON Schema tooling and consumers keep working unchanged
+- Bad, because loses Pydantic's expressive validators (`@field_validator`, `@model_validator`)
+- Bad, because adds a codegen step on every contract change
+- Bad, because leaves the wire format frozen at whatever the schema said — including its inconsistencies
 
 ### Option 3 — Hybrid: both authoritative
 
-**Pros**
-
-- Retains JSON Schema as an explicit contract artifact alongside typed Python models
-
-**Cons**
-
-- Divergence risk; CI drift checks become load-bearing
+- Good, because retains JSON Schema as an explicit contract artifact alongside typed Python models
+- Bad, because divergence risk; CI drift checks become load-bearing
 
 ### Option 4 — Keep both authoritative; regenerate JSON in CI from models
 
-**Pros**
-
-- On-disk JSON Schema files remain available for external tooling and IDE/GitHub blob view
-
-**Cons**
-
-- Extra build step with no consumer benefit once a CLI dump exposes the schema
-- On-disk files would still get stale reads in IDEs / GitHub blob view
+- Good, because on-disk JSON Schema files remain available for external tooling and IDE/GitHub blob view
+- Bad, because extra build step with no consumer benefit once a CLI dump exposes the schema
+- Bad, because on-disk files would still get stale reads in IDEs / GitHub blob view
 
 ## Decision Outcome
 

--- a/docs/adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
+++ b/docs/adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
@@ -42,60 +42,35 @@ Three pressures pushed for a docs site:
 
 ### Option 1 — mkdocs-material + mkdocstrings[python] + mkdocs-autorefs
 
-**Pros**
-
-- Renders Pydantic model fields with `description` strings inline, fulfilling ADR-0001's promise
-- Single nav covers both prose docs and auto-generated API reference
-- Mirrors the canonical `qte77/Agents-eval` setup; maintenance tracks that repo's workflow changes
-- Markdown-native authoring suits contributors who already write Markdown
-
-**Cons**
-
-- Docstrings become load-bearing for site quality; ruff `D`-rules must be enforced
-- `mkdocs.yaml` + deploy workflow + `[dependency-groups] docs` are new surface area to maintain
-- One-time manual setup required: repo `Settings → Pages → Source = "GitHub Actions"`
+- Good, because renders Pydantic model fields with `description` strings inline, fulfilling ADR-0001's promise
+- Good, because single nav covers both prose docs and auto-generated API reference
+- Good, because mirrors the canonical `qte77/Agents-eval` setup; maintenance tracks that repo's workflow changes
+- Good, because Markdown-native authoring suits contributors who already write Markdown
+- Bad, because docstrings become load-bearing for site quality; ruff `D`-rules must be enforced
+- Bad, because `mkdocs.yaml` + deploy workflow + `[dependency-groups] docs` are new surface area to maintain
+- Bad, because one-time manual setup required: repo `Settings → Pages → Source = "GitHub Actions"`
 
 ### Option 2 — Sphinx + autodoc
 
-**Pros**
-
-- Mature ecosystem with broad plugin support and extensive documentation
-
-**Cons**
-
-- Heavier, RST friction, larger learning curve for contributors who already write Markdown
-- mkdocstrings's Markdown-native authoring beats this for our docs surface
+- Good, because mature ecosystem with broad plugin support and extensive documentation
+- Bad, because heavier, RST friction, larger learning curve for contributors who already write Markdown
+- Bad, because mkdocstrings's Markdown-native authoring beats this for our docs surface
 
 ### Option 3 — pdoc
 
-**Pros**
-
-- Simpler setup with lower configuration overhead
-
-**Cons**
-
-- No prose-doc nav; the entire `docs/` tree would need a separate site or hand-curated index
+- Good, because simpler setup with lower configuration overhead
+- Bad, because no prose-doc nav; the entire `docs/` tree would need a separate site or hand-curated index
 
 ### Option 4 — Hand-written API pages
 
-**Pros**
-
-- No build tooling dependency; pages are authored and versioned directly
-
-**Cons**
-
-- Drift risk; `::: doc_pipeline_engine.stages.v2_normalize` stubs would have to be maintained by hand each time a stage is added
-- The auto-generated `docstrings.md` (one entry per `.py` module via `find src`) eliminates that need
+- Good, because no build tooling dependency; pages are authored and versioned directly
+- Bad, because drift risk; `::: doc_pipeline_engine.stages.v2_normalize` stubs would have to be maintained by hand each time a stage is added
+- Bad, because the auto-generated `docstrings.md` (one entry per `.py` module via `find src`) eliminates that need
 
 ### Option 5 — Pin `gh-pages` branch deploy (`mkdocs gh-deploy --force`)
 
-**Pros**
-
-- Familiar deploy pattern; no Pages source configuration required in repo settings
-
-**Cons**
-
-- Agents-eval moved to `actions/deploy-pages` already; following that flow keeps a second branch out of the tree
+- Good, because familiar deploy pattern; no Pages source configuration required in repo settings
+- Bad, because Agents-eval moved to `actions/deploy-pages` already; following that flow keeps a second branch out of the tree
 
 ## Decision Outcome
 

--- a/docs/adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
+++ b/docs/adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
@@ -2,14 +2,16 @@
 title: ADR-0002 — mkdocs-material + mkdocstrings for API docs
 purpose: Records the decision to use mkdocs-material with mkdocstrings[python] for the auto-generated API docs site, mirroring qte77/Agents-eval
 created: 2026-04-27
-updated: 2026-04-27
-validated_links: 2026-04-27
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: technical
 ---
 
-**Status**: Accepted (2026-04-27)
+## Status
 
-## Context
+Accepted — 2026-04-27
+
+## Context and Problem Statement
 
 §0.2.1 made Pydantic models the source of truth for stage contracts.
 The `Field(description=...)` payloads on every model are wire-doc
@@ -30,9 +32,74 @@ Three pressures pushed for a docs site:
    re-implementing instead of mirroring would create needless
    variance.
 
-## Decision
+## Decision Drivers
 
-Adopt **mkdocs-material + mkdocstrings[python] + mkdocs-autorefs**,
+- Pydantic Field rendering: `Field(description=...)` payloads are invisible without a renderer; mkdocstrings[python] renders them inline
+- Single nav for prose + API: existing prose docs and API reference deserve unified navigation
+- qte77 ecosystem precedent: mirroring Agents-eval avoids needless variance across the ecosystem
+
+## Considered Options
+
+### Option 1 — mkdocs-material + mkdocstrings[python] + mkdocs-autorefs
+
+**Pros**
+
+- Renders Pydantic model fields with `description` strings inline, fulfilling ADR-0001's promise
+- Single nav covers both prose docs and auto-generated API reference
+- Mirrors the canonical `qte77/Agents-eval` setup; maintenance tracks that repo's workflow changes
+- Markdown-native authoring suits contributors who already write Markdown
+
+**Cons**
+
+- Docstrings become load-bearing for site quality; ruff `D`-rules must be enforced
+- `mkdocs.yaml` + deploy workflow + `[dependency-groups] docs` are new surface area to maintain
+- One-time manual setup required: repo `Settings → Pages → Source = "GitHub Actions"`
+
+### Option 2 — Sphinx + autodoc
+
+**Pros**
+
+- Mature ecosystem with broad plugin support and extensive documentation
+
+**Cons**
+
+- Heavier, RST friction, larger learning curve for contributors who already write Markdown
+- mkdocstrings's Markdown-native authoring beats this for our docs surface
+
+### Option 3 — pdoc
+
+**Pros**
+
+- Simpler setup with lower configuration overhead
+
+**Cons**
+
+- No prose-doc nav; the entire `docs/` tree would need a separate site or hand-curated index
+
+### Option 4 — Hand-written API pages
+
+**Pros**
+
+- No build tooling dependency; pages are authored and versioned directly
+
+**Cons**
+
+- Drift risk; `::: doc_pipeline_engine.stages.v2_normalize` stubs would have to be maintained by hand each time a stage is added
+- The auto-generated `docstrings.md` (one entry per `.py` module via `find src`) eliminates that need
+
+### Option 5 — Pin `gh-pages` branch deploy (`mkdocs gh-deploy --force`)
+
+**Pros**
+
+- Familiar deploy pattern; no Pages source configuration required in repo settings
+
+**Cons**
+
+- Agents-eval moved to `actions/deploy-pages` already; following that flow keeps a second branch out of the tree
+
+## Decision Outcome
+
+Chosen: **Option 1 — mkdocs-material + mkdocstrings[python] + mkdocs-autorefs**,
 mirroring `/workspaces/qte77/Agents-eval/mkdocs.yaml` and its deploy
 workflow. Specifics:
 
@@ -66,21 +133,6 @@ workflow. Specifics:
 - Docs deps live in `[dependency-groups] docs` (uv-style), not
   `[project.optional-dependencies]`. Runtime deps untouched.
 
-## Rejected alternatives
-
-- **Sphinx + autodoc** — heavier, RST friction, larger learning curve
-  for contributors who already write Markdown. mkdocstrings's
-  Markdown-native authoring beats this for our docs surface.
-- **pdoc** — simpler but no prose-doc nav; the entire docs/ tree
-  would need a separate site or hand-curated index.
-- **Hand-written API pages** — drift risk; we'd have to maintain
-  `::: doc_pipeline_engine.stages.v2_normalize` stubs by hand each
-  time a stage is added. The auto-generated `docstrings.md` (one
-  entry per `.py` module via `find src`) eliminates that.
-- **Pin `gh-pages` branch deploy** (`mkdocs gh-deploy --force`) —
-  Agents-eval moved to `actions/deploy-pages` already; following
-  that flow keeps a second branch out of the tree.
-
 ## Consequences
 
 - Docstrings become load-bearing for site quality. Ruff `D`-rules
@@ -96,7 +148,7 @@ workflow. Specifics:
 - One-time manual setup: repo `Settings → Pages → Source = "GitHub
   Actions"` before the first PR-merged deploy succeeds.
 
-## Sources
+## More Information
 
 - mkdocs-material: <https://squidfunk.github.io/mkdocs-material/>
 - mkdocstrings (Python handler): <https://mkdocstrings.github.io/python/>

--- a/docs/adr/0003-rename-legs-anthropic-sdk-local.md
+++ b/docs/adr/0003-rename-legs-anthropic-sdk-local.md
@@ -2,14 +2,16 @@
 title: ADR-0003 — Rename pipeline legs `v1` → `anthropic_sdk`, `v2` → `local`
 purpose: Records the leg-naming refactor that replaces PR-ordering labels with self-describing names ahead of the external-evaluator work in §0.2.3
 created: 2026-04-27
-updated: 2026-04-27
-validated_links: 2026-04-27
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: technical
 ---
 
-**Status**: Accepted (2026-04-27)
+## Status
 
-## Context
+Accepted — 2026-04-27
+
+## Context and Problem Statement
 
 The two pipeline legs have lived under `v1` / `v2` names since
 §0.2.0. Those labels describe **PR-ordering** — the Anthropic-SDK
@@ -28,9 +30,71 @@ more than they describe:
 - The §0.2.3 external-evaluator work introduces a third comparison
   surface; calling it `v3` would compound the confusion.
 
-## Decision
+## Decision Drivers
 
-Rename the legs **before** the external evaluators land:
+- PR-ordering labels (`v1` / `v2`) describe scaffolding sequence, not leg behavior, forcing readers to look up the mapping every time
+- Transport flexibility of the Anthropic SDK leg is invisible under `v1`; locality property of the no-LLM leg is invisible under `v2`
+- A third comparison track (`§0.2.3`) would compound the confusion if named `v3`
+
+## Considered Options
+
+### Option 1 — Rename to `anthropic_sdk` / `local`
+
+**Pros**
+
+- `anthropic_sdk` describes the transport (Anthropic Python SDK), covering Anthropic cloud, Bedrock, Vertex, or any compatible endpoint
+- `local` describes the defining locality property (no LLM, no cloud calls; Tesseract OCR + optional spaCy NER)
+- Third comparison track can be named descriptively from the start without compounding confusion
+
+**Cons**
+
+- Broad mechanical rename across source files, tests, identifiers, `pyproject.toml` extras, Makefile, and output directories
+- Existing locally cached outputs from prior runs need a one-time manual rename or fresh regeneration
+
+### Option 2 — `api` / `local`
+
+**Pros**
+
+- Shorter names; `local` still carries its locality signal
+
+**Cons**
+
+- `api` understates the SDK's transport flexibility (the SDK isn't married to Anthropic cloud)
+
+### Option 3 — `sdk` / `tools`
+
+**Pros**
+
+- Mechanism-based naming is unambiguous about what each leg uses
+
+**Cons**
+
+- Pure mechanism naming; loses the locality signal `local` carries and the cloud-by-default signal `anthropic_sdk` carries
+
+### Option 4 — `llm` / `local`
+
+**Pros**
+
+- `llm` / `local` contrast is immediately intuitive to newcomers
+
+**Cons**
+
+- `llm` is generic enough to confuse with external-evaluator variants that also use LLMs (CC, external Anthropic SDK)
+
+### Option 5 — Glossary-only: keep `v1` / `v2` in code, add a doc table mapping
+
+**Pros**
+
+- Smallest diff; no code changes required
+
+**Cons**
+
+- Every new contributor still has to look up the mapping; the opacity remains in the codebase
+
+## Decision Outcome
+
+Chosen: **Option 1 — Rename to `anthropic_sdk` / `local`**. Rename the legs
+**before** the external evaluators land:
 
 - `v1` → **`anthropic_sdk`** — describes the transport (Anthropic
   Python SDK), which can point at Anthropic cloud, Bedrock, Vertex,
@@ -81,20 +145,6 @@ manual rename — `mv outputs/<sha>/v1 outputs/<sha>/anthropic_sdk`
 — or fresh runs to regenerate; the harness writes to the new
 paths after this PR.)
 
-## Rejected alternatives
-
-- **`api` / `local`** — `api` understates the SDK's transport
-  flexibility (the SDK isn't married to Anthropic cloud).
-- **`sdk` / `tools`** — pure mechanism naming; loses the locality
-  signal `local` carries (and the cloud-by-default signal
-  `anthropic_sdk` carries).
-- **`llm` / `local`** — `llm` is generic enough to confuse with
-  external-evaluator variants that also use LLMs (CC, external
-  Anthropic SDK).
-- **Glossary-only — keep `v1` / `v2` in code, add a doc table
-  mapping** — smallest diff, but every new contributor would still
-  have to look up the mapping. The opacity remains.
-
 ## Consequences
 
 - **Forward-looking docs** (architecture, roadmap, CONTRIBUTING,
@@ -110,7 +160,7 @@ paths after this PR.)
   operational cost for users with cached local outputs;
   acceptable.
 
-## Sources
+## More Information
 
 - Plan file:
   [`doc-pipeline-external-evals-and-leg-rename.md`](https://github.com/qte77/doc-pipeline-engine/issues)

--- a/docs/adr/0003-rename-legs-anthropic-sdk-local.md
+++ b/docs/adr/0003-rename-legs-anthropic-sdk-local.md
@@ -40,56 +40,31 @@ more than they describe:
 
 ### Option 1 — Rename to `anthropic_sdk` / `local`
 
-**Pros**
-
-- `anthropic_sdk` describes the transport (Anthropic Python SDK), covering Anthropic cloud, Bedrock, Vertex, or any compatible endpoint
-- `local` describes the defining locality property (no LLM, no cloud calls; Tesseract OCR + optional spaCy NER)
-- Third comparison track can be named descriptively from the start without compounding confusion
-
-**Cons**
-
-- Broad mechanical rename across source files, tests, identifiers, `pyproject.toml` extras, Makefile, and output directories
-- Existing locally cached outputs from prior runs need a one-time manual rename or fresh regeneration
+- Good, because `anthropic_sdk` describes the transport (Anthropic Python SDK), covering Anthropic cloud, Bedrock, Vertex, or any compatible endpoint
+- Good, because `local` describes the defining locality property (no LLM, no cloud calls; Tesseract OCR + optional spaCy NER)
+- Good, because third comparison track can be named descriptively from the start without compounding confusion
+- Bad, because broad mechanical rename across source files, tests, identifiers, `pyproject.toml` extras, Makefile, and output directories
+- Bad, because existing locally cached outputs from prior runs need a one-time manual rename or fresh regeneration
 
 ### Option 2 — `api` / `local`
 
-**Pros**
-
-- Shorter names; `local` still carries its locality signal
-
-**Cons**
-
-- `api` understates the SDK's transport flexibility (the SDK isn't married to Anthropic cloud)
+- Good, because shorter names; `local` still carries its locality signal
+- Bad, because `api` understates the SDK's transport flexibility (the SDK isn't married to Anthropic cloud)
 
 ### Option 3 — `sdk` / `tools`
 
-**Pros**
-
-- Mechanism-based naming is unambiguous about what each leg uses
-
-**Cons**
-
-- Pure mechanism naming; loses the locality signal `local` carries and the cloud-by-default signal `anthropic_sdk` carries
+- Good, because mechanism-based naming is unambiguous about what each leg uses
+- Bad, because pure mechanism naming; loses the locality signal `local` carries and the cloud-by-default signal `anthropic_sdk` carries
 
 ### Option 4 — `llm` / `local`
 
-**Pros**
-
-- `llm` / `local` contrast is immediately intuitive to newcomers
-
-**Cons**
-
-- `llm` is generic enough to confuse with external-evaluator variants that also use LLMs (CC, external Anthropic SDK)
+- Good, because `llm` / `local` contrast is immediately intuitive to newcomers
+- Bad, because `llm` is generic enough to confuse with external-evaluator variants that also use LLMs (CC, external Anthropic SDK)
 
 ### Option 5 — Glossary-only: keep `v1` / `v2` in code, add a doc table mapping
 
-**Pros**
-
-- Smallest diff; no code changes required
-
-**Cons**
-
-- Every new contributor still has to look up the mapping; the opacity remains in the codebase
+- Good, because smallest diff; no code changes required
+- Bad, because every new contributor still has to look up the mapping; the opacity remains in the codebase
 
 ## Decision Outcome
 

--- a/docs/adr/0004-external-evaluators-vs-pipeline.md
+++ b/docs/adr/0004-external-evaluators-vs-pipeline.md
@@ -54,49 +54,29 @@ call, defeating the "off-the-shelf" intent.
 
 ### Option 1 — External `external/` directory with standalone runners
 
-**Pros**
-
-- No pipeline stages imposed on one-shot tools; each runner is a few lines
-- Off-the-shelf realism preserved: external evaluators process the raw sample file including their own extraction
-- CC's native PDF-reading capability remains part of the test; extraction-quality differences are surfaced
-- Subscription-only users have a clear path via `external/cc_cli/run_headless.sh`
-
-**Cons**
-
-- Cost axis is asymmetric across variants (SDK per-call from envelope, CC per-session via codeburn, `local` is free)
-- Subscription-only users no longer have a V1 path; behavior change vs pre-#54 main
+- Good, because no pipeline stages imposed on one-shot tools; each runner is a few lines
+- Good, because off-the-shelf realism preserved: external evaluators process the raw sample file including their own extraction
+- Good, because CC's native PDF-reading capability remains part of the test; extraction-quality differences are surfaced
+- Good, because subscription-only users have a clear path via `external/cc_cli/run_headless.sh`
+- Bad, because cost axis is asymmetric across variants (SDK per-call from envelope, CC per-session via codeburn, `local` is free)
+- Bad, because subscription-only users no longer have a V1 path; behavior change vs pre-#54 main
 
 ### Option 2 — CC-CLI as transport fallback inside V1 stages (rolled-back #41 design)
 
-**Pros**
-
-- Single code path for all LLM-backed runs; existing V1 call sites work for CC users without separate scripts
-
-**Cons**
-
-- Runs 4 Claude calls per sample (one per stage), conflating external comparison with V1's transport choice
-- Defeats off-the-shelf intent: a real user sends one call, not four
+- Good, because single code path for all LLM-backed runs; existing V1 call sites work for CC users without separate scripts
+- Bad, because runs 4 Claude calls per sample (one per stage), conflating external comparison with V1's transport choice
+- Bad, because defeats off-the-shelf intent: a real user sends one call, not four
 
 ### Option 3 — Third in-process leg in `harness.py`
 
-**Pros**
-
-- Unified harness runs all legs; results land in the same report structure
-
-**Cons**
-
-- Forces a Stage shape onto one-shot tools; tests would have to invent fake `Discover` / `Extract` outputs for a leg that doesn't go through them
+- Good, because unified harness runs all legs; results land in the same report structure
+- Bad, because forces a Stage shape onto one-shot tools; tests would have to invent fake `Discover` / `Extract` outputs for a leg that doesn't go through them
 
 ### Option 4 — Share `Extract` output with external evaluators (apples-to-apples on summarization quality alone)
 
-**Pros**
-
-- Isolates summarization quality from extraction quality; fairer comparison of the LLM reasoning step
-
-**Cons**
-
-- Loses CC's native PDF-reading capability from the test
-- Hides extraction-quality differences, which are part of what the prototype measures
+- Good, because isolates summarization quality from extraction quality; fairer comparison of the LLM reasoning step
+- Bad, because loses CC's native PDF-reading capability from the test
+- Bad, because hides extraction-quality differences, which are part of what the prototype measures
 
 ## Decision Outcome
 

--- a/docs/adr/0004-external-evaluators-vs-pipeline.md
+++ b/docs/adr/0004-external-evaluators-vs-pipeline.md
@@ -2,14 +2,16 @@
 title: ADR-0004 — External evaluators vs the in-process pipeline
 purpose: Records the decision to ship Anthropic SDK + Claude Code one-shot summarizers as external evaluators in `external/` rather than as in-process pipeline legs
 created: 2026-04-27
-updated: 2026-04-27
-validated_links: 2026-04-27
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: technical
 ---
 
-**Status**: Accepted (2026-04-27)
+## Status
 
-## Context
+Accepted — 2026-04-27
+
+## Context and Problem Statement
 
 The in-process pipeline ships two stage-decomposed legs (`anthropic_sdk`
 and `local`, both in `src/doc_pipeline_engine/stages/`). Each leg goes
@@ -42,8 +44,63 @@ and CC's role as an external benchmark. It also made every CLI run
 execute four Claude calls (one per stage) instead of one off-the-shelf
 call, defeating the "off-the-shelf" intent.
 
-## Decision
+## Decision Drivers
 
+- Off-the-shelf one-shot summarizers must not run through pipeline stages — wedging CC-CLI into V1 executed 4 calls per sample and conflated transport with benchmarking
+- External evaluators receive the raw sample file to preserve off-the-shelf realism, including each tool's own extraction quality
+- The 2×2×3 variant matrix (Anthropic + CC × vanilla/project × headless/interactive/agent-sdk) must not force a Stage shape onto one-shot tools
+
+## Considered Options
+
+### Option 1 — External `external/` directory with standalone runners
+
+**Pros**
+
+- No pipeline stages imposed on one-shot tools; each runner is a few lines
+- Off-the-shelf realism preserved: external evaluators process the raw sample file including their own extraction
+- CC's native PDF-reading capability remains part of the test; extraction-quality differences are surfaced
+- Subscription-only users have a clear path via `external/cc_cli/run_headless.sh`
+
+**Cons**
+
+- Cost axis is asymmetric across variants (SDK per-call from envelope, CC per-session via codeburn, `local` is free)
+- Subscription-only users no longer have a V1 path; behavior change vs pre-#54 main
+
+### Option 2 — CC-CLI as transport fallback inside V1 stages (rolled-back #41 design)
+
+**Pros**
+
+- Single code path for all LLM-backed runs; existing V1 call sites work for CC users without separate scripts
+
+**Cons**
+
+- Runs 4 Claude calls per sample (one per stage), conflating external comparison with V1's transport choice
+- Defeats off-the-shelf intent: a real user sends one call, not four
+
+### Option 3 — Third in-process leg in `harness.py`
+
+**Pros**
+
+- Unified harness runs all legs; results land in the same report structure
+
+**Cons**
+
+- Forces a Stage shape onto one-shot tools; tests would have to invent fake `Discover` / `Extract` outputs for a leg that doesn't go through them
+
+### Option 4 — Share `Extract` output with external evaluators (apples-to-apples on summarization quality alone)
+
+**Pros**
+
+- Isolates summarization quality from extraction quality; fairer comparison of the LLM reasoning step
+
+**Cons**
+
+- Loses CC's native PDF-reading capability from the test
+- Hides extraction-quality differences, which are part of what the prototype measures
+
+## Decision Outcome
+
+Chosen: **Option 1 — External `external/` directory with standalone runners**.
 External one-shot summarizers live in **`external/`** as standalone
 runners, **not** as in-process pipeline stages. Their outputs land in
 `outputs/<sha>/external/<variant>/` and are compared against the
@@ -104,18 +161,6 @@ so their summaries can structurally match the pipeline output:
   output through codeburn; codeburn emits `CODEBURN_COST_USD=<float>`
   on stderr; the runner writes that to `meta.json.cost_usd`.
 
-## Rejected alternatives
-
-- **CC-CLI as transport fallback inside V1 stages** (the rolled-back
-  #41 design) — runs 4 Claude calls per sample, conflates external
-  comparison with V1's transport choice, defeats off-the-shelf intent.
-- **Third in-process leg in `harness.py`** — forces a Stage shape onto
-  one-shot tools; tests would have to invent fake `Discover` /
-  `Extract` outputs for a leg that doesn't go through them.
-- **Share `Extract` output with external evaluators** (apples-to-apples
-  on summarization quality alone) — loses CC's native PDF-reading
-  capability from the test, hides extraction-quality differences.
-
 ## Consequences
 
 - Subscription-only users no longer have a V1 path; they use
@@ -137,7 +182,7 @@ so their summaries can structurally match the pipeline output:
   (airgap-yes / airgap-conditional / airgap-no). The `local` pipeline
   is the only `airgap-yes` variant.
 
-## Sources
+## More Information
 
 - [github.com/getagentseal/codeburn](https://github.com/getagentseal/codeburn)
   — cost-monitoring wrapper for Claude Code.

--- a/docs/adr/0005-kreuzberg-elv2-license-boundary.md
+++ b/docs/adr/0005-kreuzberg-elv2-license-boundary.md
@@ -1,0 +1,108 @@
+---
+title: ADR-0005 — Pin Kreuzberg below v4.8 to stay on the MIT line; gate ELv2 as opt-in
+purpose: Records the decision to cap the kreuzberg dependency at the last MIT release and ship v4.8+ ELv2 behind an opt-in extra
+created: 2026-05-25
+updated: 2026-05-25
+validated_links: 2026-05-25
+category: technical
+---
+
+## Status
+
+Proposed — 2026-05-25
+
+## Context and Problem Statement
+
+Kreuzberg is the breadth-catch-all extraction backend wired as the
+`[extract]` extra in `pyproject.toml`. Until v4.7.x it shipped under
+MIT. Starting v4.8, upstream relicensed to Elastic License v2 (ELv2),
+a source-available licence that is not OSI-approved and prohibits
+offering the software as a managed service without Elastic's consent.
+
+GitHub's SPDX detector classifies ELv2 as `NOASSERTION`, so a casual
+audit can miss the change. The relicensing surfaced via direct
+LICENSE-file inspection (issue #76). The copyright holder also changed
+at the same time (individual → Kreuzberg, Inc.), indicating the project
+incorporated and pivoted to a source-available model in one move.
+
+Our distribution stance is Apache-2.0; consumers (polyforge,
+office-polyforge, any redistributor of doc-pipeline-engine) inherit our
+dependency licence posture. An unbounded `kreuzberg>=2.0` pin means
+`uv sync` on a fresh environment could resolve to v4.8+ and silently
+pull in ELv2. Our `uv.lock` pin was already at v4.9.5 — already on
+ELv2 — at the time of discovery.
+
+## Decision Drivers
+
+- Apache-2.0 distribution posture; ELv2 cannot be redistributed as
+  Apache-2.0
+- Embeddable-engine framing: downstream consumers must not inherit
+  source-available constraints they didn't opt into
+- Tier-G handling pattern already established in
+  `docs/landscape/domain-extraction.md` for restricted licences
+- Security backports for the MIT line become our responsibility once
+  upstream moves to ELv2-only
+- Kreuzberg's breadth (email, xlsx, legacy Office, HTML) is load-bearing
+  for v1; replacing it wholesale is out of scope
+
+## Considered Options
+
+### Option 1 — Pin `kreuzberg<4.8` as the default; ship v4.8+ ELv2 behind an opt-in `[kreuzberg-elv2]` extra
+
+**Pros**
+
+- Keeps the default install Apache-2.0-compatible
+- Preserves Kreuzberg's load-bearing breadth on the MIT line
+- Mirrors the Tier-G gating template already used for MinerU and PyMuPDF
+- Makes the licence choice explicit and downstream
+
+**Cons**
+
+- We own security backports for the MIT line going forward
+- Python 3.14 wheels may eventually require v4.8+ (re-evaluate then)
+- Extra to maintain
+
+### Option 2 — Accept ELv2 as the default
+
+**Pros**
+
+- Zero extra maintenance burden
+- Stays on the upstream-maintained line
+
+**Cons**
+
+- Bleeds ELv2 onto every consumer of `doc-pipeline-engine[extract]`
+- Source-available constraint violates the Apache-2.0 distribution
+  promise
+
+### Option 3 — Replace Kreuzberg with docling for the catch-all role
+
+**Pros**
+
+- docling is MIT and already the planned Primary layout-aware backend
+- Removes a dependency
+
+**Cons**
+
+- docling does not currently cover email, xlsx, legacy Office, or HTML
+  to Kreuzberg's breadth; gaps would need bespoke adapters
+- Out of scope for v1; wholesale extraction-stage rewrite
+
+## Decision Outcome
+
+Chosen: **Option 1**. Pin `kreuzberg<4.8` in `pyproject.toml`. Ship
+v4.8+ as an opt-in `[kreuzberg-elv2]` extra so consumers who accept the
+ELv2 constraint can opt in explicitly. Surface the thresholds and
+attribution behaviour in `NOTICE`. PR #88 implements the pin.
+
+Re-evaluate when: (a) Python 3.14 wheels require v4.8+, (b) a CVE
+backport burden becomes unsustainable, or (c) docling's coverage
+expands enough to absorb Kreuzberg's breadth niche.
+
+## More Information
+
+- Issue #76: <https://github.com/qte77/doc-pipeline-engine/issues/76>
+- PR #88: <https://github.com/qte77/doc-pipeline-engine/pull/88>
+- Tier G reference: [../landscape/domain-extraction.md#license-tier-reference](../landscape/domain-extraction.md#license-tier-reference)
+- ELv2 text: <https://www.elastic.co/licensing/elastic-license>
+- Kreuzberg releases: <https://github.com/kreuzberg-dev/kreuzberg/releases>

--- a/docs/adr/0005-kreuzberg-elv2-license-boundary.md
+++ b/docs/adr/0005-kreuzberg-elv2-license-boundary.md
@@ -49,44 +49,29 @@ ELv2 — at the time of discovery.
 
 ### Option 1 — Pin `kreuzberg<4.8` as the default; ship v4.8+ ELv2 behind an opt-in `[kreuzberg-elv2]` extra
 
-**Pros**
-
-- Keeps the default install Apache-2.0-compatible
-- Preserves Kreuzberg's load-bearing breadth on the MIT line
-- Mirrors the Tier-G gating template already used for MinerU and PyMuPDF
-- Makes the licence choice explicit and downstream
-
-**Cons**
-
-- We own security backports for the MIT line going forward
-- Python 3.14 wheels may eventually require v4.8+ (re-evaluate then)
-- Extra to maintain
+- Good, because keeps the default install Apache-2.0-compatible
+- Good, because preserves Kreuzberg's load-bearing breadth on the MIT line
+- Good, because mirrors the Tier-G gating template already used for MinerU and PyMuPDF
+- Good, because makes the licence choice explicit and downstream
+- Bad, because we own security backports for the MIT line going forward
+- Bad, because Python 3.14 wheels may eventually require v4.8+ (re-evaluate then)
+- Bad, because extra to maintain
 
 ### Option 2 — Accept ELv2 as the default
 
-**Pros**
-
-- Zero extra maintenance burden
-- Stays on the upstream-maintained line
-
-**Cons**
-
-- Bleeds ELv2 onto every consumer of `doc-pipeline-engine[extract]`
-- Source-available constraint violates the Apache-2.0 distribution
+- Good, because zero extra maintenance burden
+- Good, because stays on the upstream-maintained line
+- Bad, because bleeds ELv2 onto every consumer of `doc-pipeline-engine[extract]`
+- Bad, because source-available constraint violates the Apache-2.0 distribution
   promise
 
 ### Option 3 — Replace Kreuzberg with docling for the catch-all role
 
-**Pros**
-
-- docling is MIT and already the planned Primary layout-aware backend
-- Removes a dependency
-
-**Cons**
-
-- docling does not currently cover email, xlsx, legacy Office, or HTML
+- Good, because docling is MIT and already the planned Primary layout-aware backend
+- Good, because removes a dependency
+- Bad, because docling does not currently cover email, xlsx, legacy Office, or HTML
   to Kreuzberg's breadth; gaps would need bespoke adapters
-- Out of scope for v1; wholesale extraction-stage rewrite
+- Bad, because out of scope for v1; wholesale extraction-stage rewrite
 
 ## Decision Outcome
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,45 @@
+---
+title: Architectural Decision Records
+purpose: Index of all ADRs for doc-pipeline-engine; one line per record with status and scope
+created: 2026-05-25
+updated: 2026-05-25
+validated_links: 2026-05-25
+category: technical
+---
+
+This project records architectural decisions as
+[MADR 3.x](https://adr.github.io/madr/) Markdown files. Each ADR is
+immutable once accepted; superseded decisions are kept and cross-linked
+from the replacement.
+
+## Status legend
+
+- **Accepted** — in effect; do not edit retroactively
+- **Proposed** — under discussion; may change before acceptance
+- **Superseded by ADR-NNNN** — historical; see the linked replacement
+- **Deprecated** — no longer in effect; not yet superseded
+
+## Records
+
+| # | Title | Status | Scope |
+| --- | --- | --- | --- |
+| [0001](0001-pydantic-as-contract-source-of-truth.md) | Pydantic as the contract source of truth | Accepted (2026-04-27) | Contracts: Pydantic v2 models replace JSON Schema files |
+| [0002](0002-mkdocs-material-mkdocstrings-for-api-docs.md) | mkdocs-material + mkdocstrings for API docs | Accepted (2026-04-27) | Docs site: theme, plugin chain, GH Pages deploy |
+| [0003](0003-rename-legs-anthropic-sdk-local.md) | Rename pipeline legs `v1` → `anthropic_sdk`, `v2` → `local` | Accepted (2026-04-27) | Pipeline: self-describing leg names ahead of external evaluators |
+| [0004](0004-external-evaluators-vs-pipeline.md) | External evaluators vs the in-process pipeline | Accepted (2026-04-27) | Prototype: one-shot summarizers live in `external/`, not as stages |
+| [0005](0005-kreuzberg-elv2-license-boundary.md) | Pin Kreuzberg below v4.8 to stay on the MIT line; gate ELv2 as opt-in | Proposed (2026-05-25) | Licence: cap `kreuzberg<4.8`; ship v4.8+ behind `[kreuzberg-elv2]` extra |
+
+## Adding a new ADR
+
+1. Copy the structure from any recent ADR (e.g.,
+   [0005](0005-kreuzberg-elv2-license-boundary.md)) — it follows MADR 3.x.
+2. Filename: `NNNN-title-in-kebab-case.md` where `NNNN` is the next
+   four-digit number.
+3. Add a row to the **Records** table above.
+4. ADRs use `## More Information` (not `## Sources`) per the
+   [frontmatter convention ADR exception](../../.claude/rules/frontmatter-convention.md#adr-exception-madr-3x).
+
+## More Information
+
+- MADR 3.x spec: <https://adr.github.io/madr/>
+- ADR pattern background: <https://adr.github.io/>

--- a/docs/landscape/ingest.md
+++ b/docs/landscape/ingest.md
@@ -2,8 +2,8 @@
 title: Ingest Landscape
 purpose: Survey of extraction backends, source connectors, and crawling/discovery providers for the ingest stage
 created: 2026-04-26
-updated: 2026-04-26
-validated_links: 2026-04-26
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: landscape
 ---
 
@@ -25,7 +25,7 @@ Wired as adapters behind `base/adapter.py`. Emit `ExtractionBundle`.
 | Tool | Primary role | License | Runtime | Formats | Verdict |
 | --- | --- | --- | --- | --- | --- |
 | **docling** | Layout-aware PDF/Office → structured doc | MIT | Python + torch | PDF, DOCX, PPTX, HTML, images | **Primary** — best layout fidelity, native target for `CanonicalDoc`. |
-| **Kreuzberg** | Async multi-format extraction facade | MIT | Python (pypdfium2, Tesseract, python-docx, …) | PDF, Office, images, email, HTML | **Primary (breadth)** — covers the long tail with one adapter. |
+| **Kreuzberg** | Async multi-format extraction facade | MIT (≤4.7); ELv2 (≥4.8, Tier G — see [domain-extraction.md license tier reference](domain-extraction.md#license-tier-reference)) | Python (pypdfium2, Tesseract, python-docx, …) | PDF, Office, images, email, HTML | **Primary (breadth)** — covers the long tail with one adapter. See [ADR-0005](../adr/0005-kreuzberg-elv2-license-boundary.md). |
 | **claude_cli_adapter** | LLM-based extraction via Claude Code CLI | n/a (our code) | Claude CLI | Any (LLM-mediated) | **Primary (reference)** — end-to-end wired first; cross-validation baseline. |
 | **GLM-OCR** | Vision-LLM OCR for complex scans | Apache-2.0 | GPU preferred | Images, scanned PDF | Stub adapter — specialized scan/handwriting path. |
 | **PaddleOCR-VL** | Vision-LLM OCR, CJK-strong | Apache-2.0 | GPU preferred | Images, scanned PDF | Stub adapter — non-Latin script fallback. |

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -47,11 +47,7 @@ nav:
       - "Run 1 — V2 only": prototype/results/2026-04-26-run-1-v2-only.md
       - "Run 2 — V1+V2": prototype/results/2026-04-26-run-2-v1-cli.md
       - "Run 3 — V2 headings": prototype/results/2026-04-26-run-3-v2-headings.md
-  - ADRs:
-      - "ADR-0001 Pydantic contracts": adr/0001-pydantic-as-contract-source-of-truth.md
-      - "ADR-0002 mkdocs site": adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
-      - "ADR-0003 Rename legs": adr/0003-rename-legs-anthropic-sdk-local.md
-      - "ADR-0004 External evaluators": adr/0004-external-evaluators-vs-pipeline.md
+  - ADRs: adr/index.md
   - Contracts: contracts.md
   - Code: docstrings.md
   - Agents:


### PR DESCRIPTION
## Summary

Brings `docs/adr/` to [MADR 3.x](https://adr.github.io/madr/) compliance, adds the first new ADR (0005 — Kreuzberg ELv2 licence boundary), adds an index, and simplifies the mkdocs ADR nav.

This is **PR-A** of a 2-PR sequence. PR-B will promote the 5 buried decisions in `docs/architecture.md` lines 78–89 into ADRs 0006–0010.

## What's in this PR (7 topical commits)

1. **`chore(markdownlint)`** — disable MD036 (no-emphasis-as-heading) so MADR 3.x's `**Pros**` / `**Cons**` bold labels under each `### Option N` don't trip the linter. Narrow change with inline comment explaining intent.

2. **`docs(rules)`** — add `## ADR Exception (MADR 3.x)` section to `.claude/rules/frontmatter-convention.md`. ADRs use `## More Information` (MADR canonical) instead of `## Sources`; bare-URL precedent (`- name: <url>`) preserved. Upstreamed as proposal in qte77/claude-code-plugins#160.

3. **`docs(adr)`** — retrofit `0001 + 0002 + 0003 + 0004` to MADR 3.x:
   - Status: inline bold → `## Status` heading (date preserved)
   - `## Context` → `## Context and Problem Statement`
   - New `## Decision Drivers` extracted from existing Context (no fabrication)
   - `## Rejected alternatives` → `## Considered Options` with `### Option N — name` + `**Pros**`/`**Cons**` per option. Option 1 is the chosen one (pros/cons synthesized from existing Decision + Consequences); Options 2+ are the originally rejected alternatives.
   - `## Decision` → `## Decision Outcome` with chosen-option line
   - Existing `## Consequences` preserved verbatim after Decision Outcome
   - `## Sources` → `## More Information` (bare-URL format preserved)

4. **`docs(adr)`** — add ADR-0005 (Kreuzberg ELv2 licence boundary). Records the in-flight decision (PR #88, issue #76) to cap `kreuzberg<4.8` and ship v4.8+ ELv2 behind an opt-in `[kreuzberg-elv2]` extra. Status: **Proposed** (PR #88 still has verification gate pending).

5. **`docs(landscape/ingest)`** — Kreuzberg row was stale (listed licence MIT). Now: `MIT (≤4.7); ELv2 (≥4.8, Tier G — see [domain-extraction.md license tier reference])` + cross-link to ADR-0005.

6. **`docs(adr)`** — new `index.md` with status legend, Records table (one line per ADR), and "Adding a new ADR" guide that cross-links the new frontmatter rule carve-out. Covers 0001–0005; PR-B will extend with 0006–0010.

7. **`docs(mkdocs)`** — replace explicit 4-entry ADR nav list with single `- ADRs: adr/index.md` entry. Future ADRs require no mkdocs.yaml maintenance.

## Cross-references

- Resolves part of qte77/doc-pipeline-engine#77 (the "missing ADR-0002" turned out to exist on disk; the broader MADR compliance + new ADRs work happens here)
- Records the licence decision in flight via PR #88 (resolves #76)
- Proposes upstream rule change in qte77/claude-code-plugins#160

## Test plan

- [ ] `make lint_md` — green locally (verified, 0 errors across 33 files)
- [ ] `make lint_links` — green (CI)
- [ ] `make validate` — green (CI; chains lint + test + lint_md + lint_links)
- [ ] mkdocs build succeeds on PR-merged workflow — nav simplification didn't break the docs site
- [ ] Visual scan: every ADR has the 6 required MADR 3.x H2 sections in canonical order

## Verification done

- All 4 retrofitted ADRs preserve their existing `## Consequences` sections verbatim — no content loss
- All cross-links resolve (issues, PRs, domain-extraction.md Tier G ref, other ADRs)
- ADR-0005 Status is **Proposed** not Accepted because PR #88 hasn't merged; will be flipped when it does

Generated with Claude <noreply@anthropic.com>