### PR TITLE
docs(adr): promote architecture decisions to ADR-0006 through 0010

### DIFF
--- a/docs/adr/0006-apache-2-0-with-notice-over-mit.md
+++ b/docs/adr/0006-apache-2-0-with-notice-over-mit.md
@@ -1,0 +1,77 @@
+---
+title: ADR-0006 — Apache-2.0 with NOTICE over MIT
+purpose: Records the decision to license doc-pipeline-engine under Apache-2.0 and maintain a NOTICE file for third-party sample content
+created: 2026-05-25
+updated: 2026-05-25
+validated_links: 2026-05-25
+category: technical
+---
+
+## Status
+
+Accepted — 2026-05-25
+
+## Context and Problem Statement
+
+`doc-pipeline-engine` ships a `samples/` directory that bundles third-party
+documents under mixed licenses: US Public Domain, UK OGL v3, CC-BY 4.0,
+CC-BY-SA, arXiv non-exclusive, IETF Trust, EU Reuse Policy, World Bank Open
+Access, and Apache-2.0. These materials require attribution and a clear
+separation from the engine's own license. A license that provides a NOTICE
+file convention and a patent grant was needed to satisfy both the
+redistribution stance and the downstream consumers (polyforge,
+office-polyforge) that embed the engine.
+
+## Decision Drivers
+
+- `samples/` contains content under mixed third-party licenses requiring
+  per-file attribution in a NOTICE file
+- Downstream consumers (polyforge, office-polyforge) are Apache-2.0; clean
+  inheritance requires the same license
+- Patent grant protects contributors and consumers; MIT and BSD-3-Clause lack
+  this
+
+## Considered Options
+
+### Option 1 — Apache-2.0 with NOTICE file
+
+- Good, because includes explicit patent grant protecting contributors and users
+- Good, because NOTICE file convention is the canonical place to carry
+  per-file third-party attribution
+- Good, because Apache-2.0 → Apache-2.0 inheritance is clean for polyforge
+  and office-polyforge; MIT consumers also accept Apache-2.0
+- Bad, because slightly more ceremony than MIT for pure OSS projects without
+  mixed third-party content
+
+### Option 2 — MIT
+
+- Good, because minimal license text; widest compatibility
+- Bad, because no patent grant
+- Bad, because no NOTICE convention; third-party attribution must be handled
+  ad hoc
+
+### Option 3 — BSD-3-Clause
+
+- Good, because simple permissive license
+- Bad, because no patent grant
+- Bad, because no NOTICE convention; same attribution problem as MIT
+
+### Option 4 — MPL-2.0
+
+- Good, because file-level copyleft is a reasonable middle ground
+- Bad, because file-level copyleft adds friction for embedders who modify
+  engine source files
+
+## Decision Outcome
+
+Chosen: **Option 1**. `pyproject.toml` declares `license = "Apache-2.0"` and
+`license-files = ["LICENSE", "NOTICE"]`. The `NOTICE` file carries the
+complete per-license catalogue for `samples/` content and defers to
+`samples/SAMPLES.md` for per-file attribution. Downstream Apache-2.0
+consumers inherit cleanly; MIT consumers are also compatible.
+
+## More Information
+
+- Apache License 2.0: <https://www.apache.org/licenses/LICENSE-2.0>
+- ADR-0010 (samples gitignored): [0010-samples-gitignored-with-download-script-as-sot.md](0010-samples-gitignored-with-download-script-as-sot.md)
+- ADR-0005 (Kreuzberg ELv2 boundary): [0005-kreuzberg-elv2-license-boundary.md](0005-kreuzberg-elv2-license-boundary.md)

--- a/docs/adr/0007-two-surface-split-engine-and-control-plane.md
+++ b/docs/adr/0007-two-surface-split-engine-and-control-plane.md
@@ -1,0 +1,71 @@
+---
+title: ADR-0007 — Two-surface split: engine (data plane) and control plane
+purpose: Records the decision to separate the pipeline engine from any orchestration control plane
+created: 2026-05-25
+updated: 2026-05-25
+validated_links: 2026-05-25
+category: technical
+---
+
+## Status
+
+Accepted — 2026-05-25
+
+## Context and Problem Statement
+
+The engine handles heavy Python work: extraction, validation, and rendering.
+An orchestration layer — Claude Code plugins, agent skill chains, or any
+other orchestrator — owns skills, hooks, and agent lifecycle. Conflating the
+two surfaces would couple their release cycles and force consumers who only
+need document processing to take on orchestration dependencies they don't
+need. The architecture documents a "standalone by design" principle: no hard
+dependencies on any orchestrator; contracts are the public API.
+
+## Decision Drivers
+
+- Engine must be embeddable without an orchestrator (polyforge, any CLI
+  consumer, or plain Python import)
+- Control plane needs to evolve independently; agent patterns (P1–P4) are
+  still being evaluated
+- Contracts as the public API make the boundary explicit and
+  orchestration-agnostic
+
+## Considered Options
+
+### Option 1 — Two-surface split: engine as data plane, optional control plane
+
+- Good, because engine stays lightweight and version-independent
+- Good, because any orchestrator that can consume/produce the JSON contracts
+  can participate
+- Good, because control plane can change orchestration pattern (P1–P4)
+  without touching engine internals
+- Bad, because the boundary must be maintained deliberately; contract drift
+  could still couple the two layers
+
+### Option 2 — Integrated single surface
+
+- Good, because simpler initial setup; one import, one lifecycle
+- Bad, because couples control plane and data plane release cycles
+- Bad, because bloats the engine for consumers that need only document
+  processing
+
+### Option 3 — Thin engine with heavyweight orchestrator dependency
+
+- Good, because orchestrator provides rich tooling out of the box
+- Bad, because forces dependency direction inward; engine is no longer
+  standalone
+- Bad, because consumers inherit the orchestrator's transitive dependency
+  graph
+
+## Decision Outcome
+
+Chosen: **Option 1**. The engine exposes the 10 contracts as its only public
+surface. Orchestration lives entirely outside: Claude Code plugins, polyforge,
+or any system that can consume JSON. The four orchestration patterns (P1–P4)
+evaluated in `docs/architecture.md` all operate on the same stage graph via
+this split.
+
+## More Information
+
+- Architecture — standalone by design: [../architecture.md](../architecture.md)
+- ADR-0009 (10 contracts): [0009-ten-contracts-with-five-simplified-stubs.md](0009-ten-contracts-with-five-simplified-stubs.md)

--- a/docs/adr/0008-hatchling-and-uv-over-setuptools-and-pip.md
+++ b/docs/adr/0008-hatchling-and-uv-over-setuptools-and-pip.md
@@ -1,0 +1,77 @@
+---
+title: ADR-0008 — Hatchling + uv over setuptools + pip
+purpose: Records the decision to use Hatchling as the build backend and uv as the package manager and task runner
+created: 2026-05-25
+updated: 2026-05-25
+validated_links: 2026-05-25
+category: technical
+---
+
+## Status
+
+Accepted — 2026-05-25
+
+## Context and Problem Statement
+
+A build backend and package manager must be chosen for the project. The
+requirements are PEP 621 native configuration in `pyproject.toml`, fast
+dependency resolution for CI, and a clean dev workflow without legacy
+`setup.py` or separate `requirements.txt` files. `uv sync` replaces pip
+everywhere in the Makefile — install, test, lint, docs, and script execution
+all go through `uv run`.
+
+## Decision Drivers
+
+- PEP 621 compliance: all metadata in `pyproject.toml`, no secondary config
+  files
+- Fast resolution and install speed for CI and devcontainer startup
+- No `setup.py` or `setup.cfg` legacy baggage
+- Single tool (`uv`) covers sync, run, and extras across all Makefile targets
+
+## Considered Options
+
+### Option 1 — Hatchling + uv
+
+- Good, because Hatchling is lightweight, PEP 517/660 native, zero config
+  for standard layouts
+- Good, because `uv sync` is significantly faster than pip for resolution and
+  install
+- Good, because `uv run` replaces `python -m` / `pip run` uniformly; single
+  tool across all Makefile targets
+- Bad, because uv is a newer tool; not all environments have it pre-installed
+  (mitigated by the `setup_uv` Makefile target)
+
+### Option 2 — setuptools + pip
+
+- Good, because ubiquitous; every Python environment has pip
+- Bad, because requires `setup.py` or `setup.cfg` alongside `pyproject.toml`
+  for full feature coverage
+- Bad, because significantly slower resolution than uv
+- Bad, because legacy `setup.py` baggage is a maintenance burden
+
+### Option 3 — PDM + pip
+
+- Good, because PEP 621 native and well-regarded
+- Bad, because narrower adoption than uv; fewer devcontainer base images
+  include it
+
+### Option 4 — Poetry
+
+- Good, because mature ecosystem with lockfile support
+- Bad, because `pyproject.toml` dialect drift: Poetry uses non-standard keys
+  that can conflict with PEP 621
+- Bad, because Poetry's lockfile format is not interoperable with uv or pip
+
+## Decision Outcome
+
+Chosen: **Option 1**. `pyproject.toml` declares `requires = ["hatchling"]`
+and `build-backend = "hatchling.build"`. Every Makefile target that runs
+Python or installs deps uses `uv run` or `uv sync`. The `setup_uv` target
+bootstraps uv via pip for environments that don't have it, keeping the
+dependency on pip minimal and one-time.
+
+## More Information
+
+- Hatchling: <https://hatch.pypa.io/latest/config/build/>
+- uv: <https://docs.astral.sh/uv/>
+- PEP 621: <https://peps.python.org/pep-0621/>

--- a/docs/adr/0009-ten-contracts-with-five-simplified-stubs.md
+++ b/docs/adr/0009-ten-contracts-with-five-simplified-stubs.md
@@ -1,0 +1,73 @@
+---
+title: ADR-0009 — 10 contracts with 5 simplified stubs
+purpose: Records the decision to ship all 10 contract slots now, with five speculative schemas reduced to minimal stubs
+created: 2026-05-25
+updated: 2026-05-25
+validated_links: 2026-05-25
+category: technical
+---
+
+## Status
+
+Accepted — 2026-05-25
+
+## Context and Problem Statement
+
+The pipeline has 10 identified contract slots in the stage graph. Five are
+substantive and load-bearing now: `DiscoveryManifest`, `ExtractionBundle`,
+`CanonicalDoc`, `AnalysisReport`, `EvalReport`. Five are speculative and not
+yet wired to any stage: `ClassificationManifest`, `FormatMatch`,
+`FormatConformance`, `InputFormat`, `OutputFormat`. Shipping all 10 slots now
+versus deferring the speculative five has implications for slot numbering
+stability as the roadmap unfolds.
+
+## Decision Drivers
+
+- Slot-number stability: contract names referenced externally must not be
+  renumbered when stubs are promoted to full schemas
+- Minimal stub cost is low; a Pydantic `BaseModel` subclass with no fields
+  is a valid placeholder
+- The `REGISTRY` in `models/__init__.py` is registry-driven; adding a model
+  later requires only a field addition, not a renaming pass
+
+## Considered Options
+
+### Option 1 — 10 slots, 5 as minimal stubs
+
+- Good, because slot numbering is stable; no renaming churn when stubs are
+  promoted
+- Good, because the `REGISTRY` is complete now; downstream consumers can
+  reference all 10 names without breakage
+- Bad, because five stub models carry no fields and generate trivial schemas
+  until wired
+
+### Option 2 — Ship only the 5 substantive contracts now
+
+- Good, because no dead-weight stubs in the codebase
+- Bad, because adding the 5 speculative contracts later may require
+  renumbering if slots are taken by interim additions
+- Bad, because consumers that reference a future contract name get an import
+  error until it ships
+
+### Option 3 — Defer stub creation until each is needed
+
+- Good, because zero maintenance until the need is concrete
+- Bad, because risks contract-name collisions and breaks the slot ordering
+  established in the stage graph
+- Bad, because each addition is a breaking change for any consumer already
+  enumerating the `REGISTRY`
+
+## Decision Outcome
+
+Chosen: **Option 1**. All 10 models are registered in `REGISTRY` in
+`src/doc_pipeline_engine/models/__init__.py`. The 5 substantive models
+(`DiscoveryManifest`, `ExtractionBundle`, `CanonicalDoc`, `AnalysisReport`,
+`EvalReport`) have full field definitions. The 5 stubs
+(`ClassificationManifest`, `FormatMatch`, `FormatConformance`, `InputFormat`,
+`OutputFormat`) are minimal `BaseModel` subclasses. The roadmap documents
+when each stub gets wired.
+
+## More Information
+
+- ADR-0001 (contracts as public API): [0001-pydantic-as-contract-source-of-truth.md](0001-pydantic-as-contract-source-of-truth.md)
+- ADR-0007 (two-surface split): [0007-two-surface-split-engine-and-control-plane.md](0007-two-surface-split-engine-and-control-plane.md)

--- a/docs/adr/0010-samples-gitignored-with-download-script-as-sot.md
+++ b/docs/adr/0010-samples-gitignored-with-download-script-as-sot.md
@@ -1,0 +1,75 @@
+---
+title: ADR-0010 — Samples gitignored with download script as single source of truth
+purpose: Records the decision to exclude binary sample files from git and use a download script as the authoritative manifest
+created: 2026-05-25
+updated: 2026-05-25
+validated_links: 2026-05-25
+category: technical
+---
+
+## Status
+
+Accepted — 2026-05-25
+
+## Context and Problem Statement
+
+The `samples/` directory holds approximately 95 binary files (PDFs, images,
+Office documents, and other formats) used for pipeline testing and
+demonstration. These files are too large for git's object store and carry
+mixed third-party licenses. A strategy is needed for how contributors
+reproduce the sample corpus without committing binaries to the repository.
+
+## Decision Drivers
+
+- ~95 binary files at MB scale are too large for git without degrading
+  `git clone` performance
+- Each file has a distinct license and must carry attribution metadata
+  (URL, license, description)
+- Reproduction must be deterministic: same script, same corpus
+- License metadata must live in code, not in a separate wiki or doc
+
+## Considered Options
+
+### Option 1 — Download script + `samples/` gitignored
+
+- Good, because repo stays small; `git clone` is fast
+- Good, because the script (`scripts/download-samples.sh`) carries URL,
+  license, and description metadata per file — license metadata as code
+- Good, because `--manifest` mode regenerates `samples/SAMPLES.md` without
+  re-downloading, making attribution refresh cheap
+- Bad, because corpus reproduction requires an internet connection and a
+  manual `scripts/download-samples.sh --download` run
+
+### Option 2 — Git LFS
+
+- Good, because binaries stay in git history; no separate download step
+- Bad, because ~95 MB-scale files exhaust LFS quota on GitHub's free tier
+- Bad, because LFS adds CI complexity (credential setup, pointer management)
+- Bad, because LFS is GitHub-specific; lock-in risk if the repo moves
+
+### Option 3 — Commit binaries directly
+
+- Good, because zero setup; `git clone` gives everything
+- Bad, because repo bloat degrades `git clone` performance for all
+  contributors
+- Bad, because no structured license-metadata layer; attribution is static
+  text only
+
+### Option 4 — External CDN with hash manifest
+
+- Good, because binaries are served fast from a CDN
+- Bad, because requires additional infrastructure to host and maintain
+- Bad, because no clear win over the download script; adds an out-of-repo
+  dependency
+
+## Decision Outcome
+
+Chosen: **Option 1**. `samples/` is listed in `.gitignore`. The download
+script `scripts/download-samples.sh` is the single source of truth: it
+carries per-file metadata and regenerates `samples/SAMPLES.md` on each run.
+`NOTICE` references `samples/SAMPLES.md` as the per-file attribution index.
+
+## More Information
+
+- ADR-0006 (Apache-2.0 + NOTICE): [0006-apache-2-0-with-notice-over-mit.md](0006-apache-2-0-with-notice-over-mit.md)
+- Download script: [../../scripts/download-samples.sh](../../scripts/download-samples.sh)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -2,8 +2,8 @@
 title: Architectural Decision Records
 purpose: Index of all ADRs for doc-pipeline-engine; one line per record with status and scope
 created: 2026-05-25
-updated: 2026-05-25
-validated_links: 2026-05-25
+updated: 2026-05-26
+validated_links: 2026-05-26
 category: technical
 ---
 
@@ -28,6 +28,11 @@ from the replacement.
 | [0003](0003-rename-legs-anthropic-sdk-local.md) | Rename pipeline legs `v1` → `anthropic_sdk`, `v2` → `local` | Accepted (2026-04-27) | Pipeline: self-describing leg names ahead of external evaluators |
 | [0004](0004-external-evaluators-vs-pipeline.md) | External evaluators vs the in-process pipeline | Accepted (2026-04-27) | Prototype: one-shot summarizers live in `external/`, not as stages |
 | [0005](0005-kreuzberg-elv2-license-boundary.md) | Pin Kreuzberg below v4.8 to stay on the MIT line; gate ELv2 as opt-in | Proposed (2026-05-25) | Licence: cap `kreuzberg<4.8`; ship v4.8+ behind `[kreuzberg-elv2]` extra |
+| [0006](0006-apache-2-0-with-notice-over-mit.md) | Apache-2.0 with NOTICE over MIT | Accepted (2026-05-25) | Licence: patent grant + NOTICE for mixed-licence samples content |
+| [0007](0007-two-surface-split-engine-and-control-plane.md) | Two-surface split: engine (data plane) vs control plane | Accepted (2026-05-25) | Architecture: engine stays embeddable; orchestrator-agnostic via contracts |
+| [0008](0008-hatchling-and-uv-over-setuptools-and-pip.md) | Hatchling + uv over setuptools + pip | Accepted (2026-05-25) | Toolchain: PEP 621 native; `uv sync` replaces pip everywhere |
+| [0009](0009-ten-contracts-with-five-simplified-stubs.md) | 10 contracts shipped with 5 simplified stubs | Accepted (2026-05-25) | Contracts: slot reservation; ClassificationManifest / FormatMatch / FormatConformance / InputFormat / OutputFormat as stubs |
+| [0010](0010-samples-gitignored-with-download-script-as-sot.md) | Samples gitignored via download script as single source of truth | Accepted (2026-05-25) | Samples: `scripts/download-samples.sh` is SoT; binaries not in git |
 
 ## Adding a new ADR
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,8 @@
 title: Architecture
 purpose: Stage graph, contracts, runtime modes, and design decisions for the pipeline engine
 created: 2026-04-23
-updated: 2026-04-27
-validated_links: 2026-04-26
+updated: 2026-05-25
+validated_links: 2026-05-25
 category: technical
 ---
 
@@ -76,14 +76,12 @@ Quick draft always produced first — doubles as the executive summary inside co
 
 ## Design decisions
 
-**Two-surface split** — the engine is the data plane (heavy Python: extraction, validation, rendering). An optional control plane (Claude Code plugin or other orchestrator) owns skills, agents, hooks. Separation lets the engine stay lightweight and version independently.
+Architectural decisions live as ADRs under [`adr/`](adr/index.md). Quick index of the made decisions:
 
-**Four orchestration patterns** (to be evaluated) — P1: plain skill chain, P2: parallel subagents, P3: team mode, P4: hybrid. All run the same stage graph; they differ in who runs each stage. Contracts are orchestration-agnostic by design.
+- [ADR-0006](adr/0006-apache-2-0-with-notice-over-mit.md) — Apache-2.0 with NOTICE over MIT
+- [ADR-0007](adr/0007-two-surface-split-engine-and-control-plane.md) — Two-surface split (engine vs control plane)
+- [ADR-0008](adr/0008-hatchling-and-uv-over-setuptools-and-pip.md) — Hatchling + uv over setuptools + pip
+- [ADR-0009](adr/0009-ten-contracts-with-five-simplified-stubs.md) — 10 contracts shipped with 5 simplified stubs
+- [ADR-0010](adr/0010-samples-gitignored-with-download-script-as-sot.md) — Samples gitignored; download script is the single source of truth
 
-**Apache-2.0 over MIT** — Apache-2.0 includes patent grant and NOTICE file support. NOTICE is needed because `samples/` bundles third-party content under mixed licenses (CC-BY, Public Domain, IETF Trust, EU reuse).
-
-**Hatchling over setuptools** — lighter, faster, PEP 621 native. `uv sync` replaces pip everywhere.
-
-**10 contracts, 5 simplified** — all 10 schemas kept to reserve contract slots. Five speculative schemas (ClassificationManifest, FormatMatch, FormatConformance, InputFormat, OutputFormat) reduced to minimal stubs. Roadmap documents when each gets wired.
-
-**Samples gitignored** — ~95 binary files too large for git. Download script is the single source of truth — carries metadata (URL, license, description) and generates `samples/SAMPLES.md` on each run.
+**Four orchestration patterns** (to be evaluated; no ADR yet) — P1: plain skill chain, P2: parallel subagents, P3: team mode, P4: hybrid. All run the same stage graph; they differ in who runs each stage. Contracts are orchestration-agnostic by design.


### PR DESCRIPTION
## Summary

**PR-B** of the 2-PR MADR 3.x sequence (PR-A was #97, merged). Promotes the 5 made architectural decisions buried in `docs/architecture.md` lines 78–89 into proper MADR 3.x ADRs, replaces the inline narrative with cross-refs, and extends `docs/adr/index.md` accordingly.

## What's in this PR (6 topical commits)

| # | Commit | What it adds |
|---|---|---|
| 1 | `docs(adr): add 0006 — Apache-2.0 + NOTICE over MIT` | Licence choice: 4 options (Apache-2.0 / MIT / BSD-3-Clause / MPL-2.0); patent grant + NOTICE for mixed-licence `samples/` |
| 2 | `docs(adr): add 0007 — two-surface split` | Architectural boundary: engine = data plane; optional control plane owns skills/agents/hooks |
| 3 | `docs(adr): add 0008 — Hatchling + uv over setuptools + pip` | Toolchain: PEP 621 native; 4 options (Hatchling+uv / setuptools+pip / PDM / Poetry) |
| 4 | `docs(adr): add 0009 — 10 contracts with 5 simplified stubs` | Slot-reservation: ship 10 contract slots, 5 stubs (ClassificationManifest / FormatMatch / FormatConformance / InputFormat / OutputFormat) |
| 5 | `docs(adr): add 0010 — samples gitignored via download script as SoT` | Samples handling: `scripts/download-samples.sh` is SoT; binaries not in git; 4 options (script / Git LFS / commit binaries / external CDN) |
| 6 | `docs(architecture): replace inline Design decisions with ADR cross-refs; extend ADR index` | architecture.md becomes an index of ADR links; the "Four orchestration patterns (P1–P4)" pre-decision bullet stays as-is |

## Source material

All 5 new ADRs reconstruct their rationale from `architecture.md` lines 78–89 plus directly-cited project files (`LICENSE`, `NOTICE`, `pyproject.toml`, `Makefile`, `src/doc_pipeline_engine/models/`, `scripts/download-samples.sh`). **No fabrication** — claims trace to source.

## Cross-references

- Resolves the "buried decisions" half of the MADR audit raised in PR #97 review
- ADR-0006 cross-links ADR-0010 (samples) and ADR-0005 (Kreuzberg ELv2 boundary)
- ADR-0007 cross-links ADR-0009 (contracts surface materialises the engine/control-plane boundary)
- ADR-0009 cross-links ADR-0001 (Pydantic) and ADR-0007 (two-surface)
- ADR-0010 cross-links ADR-0006 (NOTICE catalogue)

## Out of scope

- The "Four orchestration patterns P1–P4" bullet remains as inline architecture.md narrative because it's explicitly pre-decision (no ADR until the evaluation lands)
- spaCy as local-leg NER, DeepEval as faithfulness probe — adjacent unrecorded decisions queued for a future cycle (not in `architecture.md`'s lines 78–89)

## Test plan

- [ ] `make lint_md` — green locally (verified, 0 errors across 38 files)
- [ ] `make lint_links` — green (CI)
- [ ] `make validate` — green (CI; chains lint + test + lint_md + lint_links)
- [ ] mkdocs build on PR-merged: nav still points at `adr/index.md`; the new ADRs auto-list via the index page (no `mkdocs.yaml` edit needed thanks to PR #97's nav simplification)
- [ ] Visual scan: every new ADR has the 6 required MADR 3.x H2 sections (Status, Context and Problem Statement, Decision Drivers, Considered Options, Decision Outcome, More Information) in canonical order, plus MADR-canonical inline `- Good, because …` / `- Bad, because …` bullets per option

## What this PR is NOT

- Not the place to debate any of these 5 decisions — they're already in force; this just records them per MADR. Reversing any decision is a separate ADR with `superseded by ADR-NNNN` status.

Generated with Claude <noreply@anthropic.com>