### PR TITLE
fix(docs/llms): point landscape entry at e2e-systems.md (was stale prior-art.md)

### DIFF
--- a/.github/templates/llms.txt.tpl
+++ b/.github/templates/llms.txt.tpl
@@ -18,7 +18,7 @@
 - [Landscape — Ingest](${BLOB}/docs/landscape/ingest.md): Extraction backends, source connectors, crawling
 - [Landscape — Process](${BLOB}/docs/landscape/process.md): Chunking, NER, RAG indexing, normalization
 - [Landscape — Output](${BLOB}/docs/landscape/output.md): Rendering, office formats, templating, conformance
-- [Landscape — Prior art](${BLOB}/docs/landscape/prior-art.md): E2E pipeline competitors and USP positioning
+- [Landscape — E2E systems](${BLOB}/docs/landscape/e2e-systems.md): End-to-end pipeline competitors, prior art, and USP positioning
 
 ## Governance
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -18,7 +18,7 @@
 - [Landscape — Ingest](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/ingest.md): Extraction backends, source connectors, crawling
 - [Landscape — Process](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/process.md): Chunking, NER, RAG indexing, normalization
 - [Landscape — Output](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/output.md): Rendering, office formats, templating, conformance
-- [Landscape — Prior art](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/prior-art.md): E2E pipeline competitors and USP positioning
+- [Landscape — E2E systems](https://github.com/qte77/doc-pipeline-engine/blob/main/docs/landscape/e2e-systems.md): End-to-end pipeline competitors, prior art, and USP positioning
 
 ## Governance
 


### PR DESCRIPTION
## Summary

`docs/landscape/prior-art.md` was renamed to `e2e-systems.md` in #83. The `.github/templates/llms.txt.tpl` template and its generated `docs/llms.txt` sibling kept the stale path, producing a 404 for any consumer following the link from `llms.txt`.

## Why CI didn't catch this

The lychee step in `qte77/.github`'s reusable workflow scans `**/*.md` only. `docs/llms.txt` is a `.txt`, so the broken URL never reached CI. Local `make lint_links` (whole-repo scope) does flag it — surfaced during PR #97 / #99 verification.

## Change

Both files updated identically:

- Link path: `docs/landscape/prior-art.md` → `docs/landscape/e2e-systems.md`
- Label: "Prior art" → "E2E systems"
- Description tightened: "End-to-end pipeline competitors, prior art, and USP positioning" (matches the file's actual scope)

## Test plan

- [ ] `make lint_links` — green locally (verified, 0 errors / 350 URLs checked)
- [ ] CI `lint / links` — green (doesn't lint `.txt` so this is unchanged)
- [ ] `make lint_md` — green (no markdown files touched)

## Follow-up (not in this PR)

Consider widening CI lychee scope to include `*.txt` (and any other doc formats) so this class of bug fails CI in future. That's a `qte77/.github` reusable-workflow change, separate from this fix.

Generated with Claude <noreply@anthropic.com>