### PR TITLE
chore(deps): pin Kreuzberg to MIT line (<4.8) + opt-in ELv2 extra (resolves #76; supersedes #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Pin `extract` extra to `kreuzberg>=2.0,<4.8` to stay on the MIT line
+  (v4.7.4 is the last MIT release; upstream relicensed to Elastic License 2.0
+  starting at v4.8.0 on 2026-04-08). New opt-in `[kreuzberg-elv2]` extra
+  (`kreuzberg>=4.8`) for downstream consumers comfortable with ELv2
+  restrictions (no managed-service offering, attribution required). Default
+  install path stays Apache-2.0-clean. See
+  [ADR-0005](docs/adr/0005-kreuzberg-elv2-license-boundary.md). Resolves #76.
+
 ### Added
 
 - `docs/landscape/domain-extraction.md` — new sibling landscape file surveying fine-tuned + domain-pretrained extraction models per industry (biomedical, legal, financial, scientific/patents, cybersecurity, HR, retail, agriculture/food, plus sparse-domain sections for mech-elec-cert and government/regulatory). Includes License tier reference (Apache/MIT / BSD / LGPL / CC-BY-SA / CC-BY-NC / GPL-AGPL / Undeclared) and PHI/de-identification cross-cutting note. Distinct from `process.md` (stage-scoped) — this file is domain-scoped.

--- a/docs/adr/0005-kreuzberg-elv2-license-boundary.md
+++ b/docs/adr/0005-kreuzberg-elv2-license-boundary.md
@@ -2,14 +2,14 @@
 title: ADR-0005 — Pin Kreuzberg below v4.8 to stay on the MIT line; gate ELv2 as opt-in
 purpose: Records the decision to cap the kreuzberg dependency at the last MIT release and ship v4.8+ ELv2 behind an opt-in extra
 created: 2026-05-25
-updated: 2026-05-25
-validated_links: 2026-05-25
+updated: 2026-05-26
+validated_links: 2026-05-26
 category: technical
 ---
 
 ## Status
 
-Proposed — 2026-05-25
+Accepted — 2026-05-26
 
 ## Context and Problem Statement
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,19 @@ dependencies = [
 [project.optional-dependencies]
 # Install with: uv sync --extra extract
 # Kreuzberg covers PDF/Office/images/email/text via Tesseract+pypdfium2.
-# MIT, local-only, no cloud.
+# MIT (≤ v4.7.4) — pinned to the last MIT release. Upstream relicensed to
+# Elastic License 2.0 starting at v4.8.0 (2026-04-08); see ADR-0005 and issue #76.
+# For the ELv2 line, install the [kreuzberg-elv2] extra instead.
 extract = [
-  "kreuzberg>=2.0",
+  "kreuzberg>=2.0,<4.8",
+]
+# Install with: uv sync --extra kreuzberg-elv2
+# Latest Kreuzberg under Elastic License 2.0 (source-available, not OSI-OSS).
+# ELv2 restricts offering the software as a managed/hosted service to third
+# parties. Use only if your deployment is comfortable with that constraint.
+# See ADR-0005.
+kreuzberg-elv2 = [
+  "kreuzberg>=4.8",
 ]
 # Install with: uv sync --extra render
 # Shared rendering: Markdown → HTML → PDF (WeasyPrint), Markdown → DOCX (python-docx).


### PR DESCRIPTION
## Summary

Supersedes #88. Rebases the original Kreuzberg pin work onto current main and removes the duplicate ADR file (the canonical ADR-0005 now lives at `docs/adr/0005-kreuzberg-elv2-license-boundary.md` per PR #97; the original branch's `0005-kreuzberg-elv2-mitigation.md` would have collided).

## Background

PR #88 was opened before PR #97 / #99 landed today. Two complications surfaced:

1. **ADR-0005 filename collision** — PR #88 had its own `0005-kreuzberg-elv2-mitigation.md`; main has `0005-kreuzberg-elv2-license-boundary.md` (MADR 3.x format, landed via #97 with `Status: Proposed` pending PR #88).
2. **Stale rebase target** — PR #88 was based on main from before the landscape audit (#95), MADR retrofit (#97), buried-decision ADRs (#99), and llms.txt fix (#101) all merged today.

A rebase attempted in this session hit a persistent sandbox-level lock on `pyproject.toml` (unrelated to git itself — `unable to unlink old 'pyproject.toml': Device or resource busy`). Reconstructed the branch cleanly off current main instead.

## 3 commits

1. `chore(deps): pin Kreuzberg to MIT line (<4.8) + opt-in ELv2 extra` — the actual `pyproject.toml` change. Caps `[extract]` at `kreuzberg<4.8`; adds new opt-in `[kreuzberg-elv2]` extra at `kreuzberg>=4.8`.
2. `docs(adr): flip ADR-0005 Status Proposed → Accepted (PR #88 v2 implements pin)` — main's ADR-0005 was `Status: Proposed` pending PR #88's implementation; this PR is the implementation, so flip it to `Accepted`. Bumps frontmatter dates to 2026-05-26.
3. `chore(changelog): add Security entry for Kreuzberg ELv2 mitigation` — Unreleased `### Security` entry cross-linking ADR-0005.

## What was NOT carried over from PR #88

- `docs/adr/0005-kreuzberg-elv2-mitigation.md` — superseded by main's canonical `0005-kreuzberg-elv2-license-boundary.md` (more thorough; MADR 3.x).
- `mkdocs.yaml` nav entry for the old ADR — main now uses `adr/index.md` auto-listing (PR #97), so no explicit nav entry needed.
- `docs/landscape/ingest.md` Kreuzberg row update — already on main (PR #97).

## Test plan

- [ ] `make lint_md` — green locally (verified, 0 errors across 38 files)
- [ ] `make lint_links` — green (CI)
- [ ] `make validate` — green (CI)
- [ ] `uv sync --extra extract` resolves to `kreuzberg<4.8` (manual verify post-merge)
- [ ] `uv sync --extra kreuzberg-elv2` resolves to `kreuzberg>=4.8` (manual verify post-merge)

## Follow-up

Close PR #88 with a redirect comment to this PR. Done as a separate gh action right after this PR is opened.

Resolves #76. Supersedes #88.

Generated with Claude <noreply@anthropic.com>