### PR TITLE
docs: architecture SVG relocation + doc audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `docs/assets/architecture-bird.svg` → `docs/assets/images/architecture-bird.svg`: relocated under an `images/` subdirectory to match the cross-repo convention now shared with `qte77/utils-pseudonomyze-text`. Reference in `docs/architecture.md` updated.
+- `docs/architecture.md`: bird's-eye SVG embed wrapped in a collapsed `<details>` block (summary "Architecture overview (click to expand)") so the doc stays scannable.
+- `docs/assets/images/architecture-bird.svg` `<style>`: added `@media (max-width: 600px)` rule that hides the three lane labels (`.lane-label`, `.lane-sub`) below 600 px rendered width, where they become illegible.
+
+### Removed
+
+- Bird's-eye SVG embed at the top of `README.md`. The diagram now lives only in `docs/architecture.md` (collapsed) — README top is reserved for orientation (name, badges, value prop).
+
+### Fixed
+
+- `docs/roadmap.md` § 0.2.2: status `in progress` → `done` — all Delivered items shipped, ADR-0002 Accepted.
+- `docs/roadmap.md` § 0.2.2: stale claim "embedded in `docs/architecture.md` and `README.md`" replaced — SVG now only in `docs/architecture.md` (inside `<details>`) at the new `docs/assets/images/` path.
+- `docs/roadmap.md` § 0.2.3: status updated — PR A (#54) and PR B delivered; only PR C (CC SDK) remains deferred (gated on `claude-agent-sdk` PyPI availability).
+- `docs/roadmap.md` § Future PDF roundtrip bullet: broken cross-repo anchor `pseudonymize-text/.../USAGE.md#pdfs-via-doc-pipeline-engine` removed (anchor never existed on the target side); now links to `pseudonymize-text/.../docs/roadmap.md`.
+- `docs/roadmap.md` frontmatter: `validated_links` date refreshed to 2026-05-31.
+- `docs/adr/index.md`: ADR-0005 row status `Proposed (2026-05-25)` → `Accepted (2026-05-26)` (matched the ADR file's own status header).
+- `docs/adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md` § Decision Outcome: nav-claim "ADRs (0001, 0002)" → "ADRs (via `adr/index.md`)" — nav was simplified to a single entry covering all ADRs.
+- `docs/adr/0002-…` § Option 4: stale `v2_normalize` module reference updated to `local_normalize` per ADR-0003.
+- `docs/adr/0004-external-evaluators-vs-pipeline.md` § Consequences: `V1` / `V2` leg names replaced with `anthropic_sdk` / `local` per ADR-0003 (Consequences should reflect post-decision state).
+- `README.md` Devcontainer section: `make install_v2_nlp` → `make install_local_nlp`; surrounding "V1 stages" / "V2 NER entities" wording updated to canonical leg names per ADR-0003.
+- `mkdocs.yaml`: `Code: docstrings.md` nav line annotated as build-artifact-generated-at-deploy (per ADR-0002), so a reader doesn't mistake the absent working-tree file for a defect.
+
 ### Security
 
 - Pin `extract` extra to `kreuzberg>=2.0,<4.8` to stay on the MIT line
@@ -71,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `docs/landscape/prior-art.md` → `e2e-systems.md` (+ companion-link updates in three sibling landscape files + `mkdocs.yaml` nav + `README.md` + `CONTRIBUTING.md` + `docs/prototype/plan.md`) + GLM-OCR References URL fix in `ingest.md` (`zai-org/GLM-4` → `zai-org/GLM-OCR`). (#83)
 - Enable Ruff `S` (bandit) and `C90` (mccabe, `max-complexity=10`); `tests/**` get `S101` ignore. Resolves #72; follow-up #75 tracks remaining rules. (#79)
 - Migrate markdown linting from `markdownlint-cli` to `markdownlint-cli2` (single-file config in `.markdownlint-cli2.jsonc`).
-- `docs/assets/architecture-bird.svg` redrawn with three lanes (anthropic_sdk + local + external evaluators side-panel).
+- Bird's-eye architecture SVG redrawn with three lanes (anthropic_sdk + local + external evaluators side-panel); later relocated to `docs/assets/images/architecture-bird.svg` per the Changed entry above.
 - Pipeline legs renamed: `v1` → `anthropic_sdk`, `v2` → `local`. Output dirs, extras, Makefile targets, CLI flag, and stage filenames updated. Deprecated aliases ship for one cycle. See [ADR-0003](docs/adr/0003-rename-legs-anthropic-sdk-local.md).
 - Pydantic v2 models replace the JSON-Schema gate as the contract source-of-truth. See [ADR-0001](docs/adr/0001-pydantic-as-contract-source-of-truth.md).
 - `stages/local_normalize.py` (formerly `v2_normalize`) — flat heading tree via three regex families with 50% density-cap fallback. Resolves [#33](https://github.com/qte77/doc-pipeline-engine/issues/33).

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 Modular document processing engine with contract-gated pipeline stages. Standalone module — usable independently or as a component in larger systems (e.g. polyforge, office-polyforge).
 
-![Pipeline overview — Discover → Extract → V1/V2 fork → Eval](docs/assets/architecture-bird.svg)
-
 ## Quickstart
 
 ```bash
@@ -21,12 +19,11 @@ make test_contracts # schema round-trip tests
 Reproducible dev env at `.devcontainer/devcontainer.json` (Python 3.13 + Claude Code + lint tooling). Optional system deps install on demand per use case:
 
 - `make install_image_ocr` — Tesseract for image-sample extraction
-- `make install_v2_nlp` — spaCy `en_core_web_sm` for V2 NER entities
+- `make install_local_nlp` — spaCy `en_core_web_sm` for `local`-leg NER entities
 
-V1 stages (Claude API leg) work with either `ANTHROPIC_API_KEY` set
-(uses the Anthropic SDK) or the `claude` CLI on PATH (uses the user's
-Claude subscription). Set neither and the stages raise with install
-hints.
+`anthropic_sdk` stages work with `ANTHROPIC_API_KEY` set (uses the
+Anthropic SDK). Subscription-only users run `external/cc_cli/run_headless.sh`
+instead — see [ADR-0004](docs/adr/0004-external-evaluators-vs-pipeline.md).
 
 ## Docs
 

--- a/docs/adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
+++ b/docs/adr/0002-mkdocs-material-mkdocstrings-for-api-docs.md
@@ -64,7 +64,7 @@ Three pressures pushed for a docs site:
 ### Option 4 — Hand-written API pages
 
 - Good, because no build tooling dependency; pages are authored and versioned directly
-- Bad, because drift risk; `::: doc_pipeline_engine.stages.v2_normalize` stubs would have to be maintained by hand each time a stage is added
+- Bad, because drift risk; `::: doc_pipeline_engine.stages.local_normalize` stubs would have to be maintained by hand each time a stage is added
 - Bad, because the auto-generated `docstrings.md` (one entry per `.py` module via `find src`) eliminates that need
 
 ### Option 5 — Pin `gh-pages` branch deploy (`mkdocs gh-deploy --force`)
@@ -88,8 +88,8 @@ workflow. Specifics:
   `paths: [src]` + `show_root_heading: true` +
   `show_submodules: true`.
 - Nav covers Home (README), Architecture, Roadmap, Landscape (4),
-  Prototype (plan + samples + 3 results), ADRs (0001, 0002), Code
-  (auto-generated `docstrings.md`), Contributing, Changelog,
+  Prototype (plan + samples + 3 results), ADRs (via `adr/index.md`),
+  Code (auto-generated `docstrings.md`), Contributing, Changelog,
   License.
 - **`docs/index.md`, `docs/docstrings.md`, and the README/CHANGELOG/
   LICENSE/CONTRIBUTING/AGENTS copies** are **build artifacts** —

--- a/docs/adr/0004-external-evaluators-vs-pipeline.md
+++ b/docs/adr/0004-external-evaluators-vs-pipeline.md
@@ -143,12 +143,12 @@ so their summaries can structurally match the pipeline output:
 
 ## Consequences
 
-- Subscription-only users no longer have a V1 path; they use
-  `external/cc_cli/run_headless.sh` instead. Behavior change vs
-  pre-#54 main.
-- Cost axis is asymmetric (V1 reports per-call from SDK envelope, V2
-  is free, external CC variants report per-session via codeburn,
-  external Anthropic variants report per-call). Apples-to-apples cost
+- Subscription-only users no longer have an `anthropic_sdk` in-process
+  path; they use `external/cc_cli/run_headless.sh` instead. Behavior
+  change vs pre-#54 main.
+- Cost axis is asymmetric (`anthropic_sdk` reports per-call from SDK
+  envelope, `local` is free, external CC variants report per-session
+  via codeburn, external Anthropic variants report per-call). Apples-to-apples cost
   view is a §0.6.0 Eval concern; for run-4 we surface the differences
   honestly and let the reader normalize.
 - The 2×2×3 variant matrix is large but each cell is a few lines;

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -27,7 +27,7 @@ from the replacement.
 | [0002](0002-mkdocs-material-mkdocstrings-for-api-docs.md) | mkdocs-material + mkdocstrings for API docs | Accepted (2026-04-27) | Docs site: theme, plugin chain, GH Pages deploy |
 | [0003](0003-rename-legs-anthropic-sdk-local.md) | Rename pipeline legs `v1` → `anthropic_sdk`, `v2` → `local` | Accepted (2026-04-27) | Pipeline: self-describing leg names ahead of external evaluators |
 | [0004](0004-external-evaluators-vs-pipeline.md) | External evaluators vs the in-process pipeline | Accepted (2026-04-27) | Prototype: one-shot summarizers live in `external/`, not as stages |
-| [0005](0005-kreuzberg-elv2-license-boundary.md) | Pin Kreuzberg below v4.8 to stay on the MIT line; gate ELv2 as opt-in | Proposed (2026-05-25) | Licence: cap `kreuzberg<4.8`; ship v4.8+ behind `[kreuzberg-elv2]` extra |
+| [0005](0005-kreuzberg-elv2-license-boundary.md) | Pin Kreuzberg below v4.8 to stay on the MIT line; gate ELv2 as opt-in | Accepted (2026-05-26) | Licence: cap `kreuzberg<4.8`; ship v4.8+ behind `[kreuzberg-elv2]` extra |
 | [0006](0006-apache-2-0-with-notice-over-mit.md) | Apache-2.0 with NOTICE over MIT | Accepted (2026-05-25) | Licence: patent grant + NOTICE for mixed-licence samples content |
 | [0007](0007-two-surface-split-engine-and-control-plane.md) | Two-surface split: engine (data plane) vs control plane | Accepted (2026-05-25) | Architecture: engine stays embeddable; orchestrator-agnostic via contracts |
 | [0008](0008-hatchling-and-uv-over-setuptools-and-pip.md) | Hatchling + uv over setuptools + pip | Accepted (2026-05-25) | Toolchain: PEP 621 native; `uv sync` replaces pip everywhere |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,12 @@ validated_links: 2026-05-25
 category: technical
 ---
 
-![Pipeline overview — Discover → Extract → V1/V2 fork → Eval](assets/architecture-bird.svg)
+<details>
+<summary>Architecture overview (click to expand)</summary>
+
+![Pipeline overview — Discover → Extract → V1/V2 fork → Eval](assets/images/architecture-bird.svg)
+
+</details>
 
 ## Core idea
 

--- a/docs/assets/images/architecture-bird.svg
+++ b/docs/assets/images/architecture-bird.svg
@@ -18,6 +18,9 @@
     .edge-cmp { stroke: #5b2a86; stroke-width: 1; stroke-dasharray: 4 3; fill: none; marker-end: url(#arrow); }
     .edge-label { font: 500 11px ui-monospace, "SFMono-Regular", monospace; fill: #52606d; text-anchor: middle; }
     .arrow-head { fill: #1f2933; }
+    @media (max-width: 600px) {
+      .lane-label, .lane-sub { display: none; }
+    }
     @media (prefers-color-scheme: dark) {
       .bg { fill: #0d1117; }
       .node { fill: #161b22; stroke: #c9d1d9; }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,8 +2,8 @@
 title: Roadmap
 purpose: Versioned milestones (0.1 → 0.6+) with status, scope, and reasoning per release
 created: 2026-04-23
-updated: 2026-04-27
-validated_links: 2026-04-26
+updated: 2026-05-28
+validated_links: 2026-05-31
 category: requirements
 ---
 
@@ -61,7 +61,7 @@ Pydantic v2 models replace the JSON-Schema gate. Models become the single source
 
 ## 0.2.2 — API docs site
 
-**Status**: in progress
+**Status**: done
 
 mkdocs-material + mkdocstrings serves the public API reference and the existing prose tree on GitHub Pages. Pydantic `Field(description=...)` payloads from §0.2.1 render inline.
 
@@ -72,12 +72,12 @@ mkdocs-material + mkdocstrings serves the public API reference and the existing 
 - `[dependency-groups] docs` in `pyproject.toml` (`mkdocs`, `mkdocs-material`, `mkdocstrings[python]`, `mkdocs-autorefs`).
 - `make docs`, `make docs_serve`, `make docs_index` Makefile targets.
 - Google-style docstring pass on `src/doc_pipeline_engine/` enforced by ruff `D`-rules.
-- Bird's-eye architecture SVG with `prefers-color-scheme` theming, embedded in `docs/architecture.md` and `README.md`.
+- Bird's-eye architecture SVG at `docs/assets/images/architecture-bird.svg` with `prefers-color-scheme` theming, embedded inside a `<details>` block in `docs/architecture.md`.
 - ADR-0002 records the decision.
 
 ## 0.2.3 — Rename legs + external evaluators
 
-**Status**: in progress (PR A merged via #54; PR B + run-4 results doc remain)
+**Status**: done for PR A (#54) + PR B; PR C (CC SDK) deferred — gated on PyPI availability
 
 Two-step refactor:
 
@@ -162,3 +162,4 @@ Evaluation harnesses and quality gates.
 - Graph-RAG
 - Certification packages (ISO 13485, IEC 62304, 21 CFR Part 11)
 - CAD/LOB ingest
+- PDF roundtrip pseudonymization — pair Extract with [`utils-pseudonomyze-text`](https://github.com/qte77/pseudonymize-text) and rebuild a redacted PDF that preserves layout. Today only the extracted text can be tokenized (`pseudonymize` defers PDF input per its [roadmap](https://github.com/qte77/pseudonymize-text/blob/main/docs/roadmap.md)); the original PDF cannot be reassembled.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -49,7 +49,8 @@ nav:
       - "Run 3 — V2 headings": prototype/results/2026-04-26-run-3-v2-headings.md
   - ADRs: adr/index.md
   - Contracts: contracts.md
-  - Code: docstrings.md
+  - Code: docstrings.md  # build artifact, gitignored; generated at deploy time per ADR-0002
+
   - Agents:
       - Rules: AGENTS.md
       - Learnings: AGENT_LEARNINGS.md


### PR DESCRIPTION
  ## Summary                                                                                                                                      
                                                                                                                                                  
  Lands the cross-repo SVG convention shared with `qte77/pseudonymize-text` and clears a 12-finding doc audit. Nine topical commits — see
  individual messages.                                                                                                                            
                                                                                                                                                  
  - **Architecture SVG** — relocated `docs/assets/architecture-bird.svg` → `docs/assets/images/architecture-bird.svg`, wrapped in a collapsed     
  `<details>` block in `docs/architecture.md`, removed from the top of `README.md`. README stays focused on orientation; the diagram lives in its
  proper home.                                                       
  - **Doc-vs-state drift fixed (roadmap)** — § 0.2.2 `in progress` → `done`; stale "embedded in `README.md`" claim removed; § 0.2.3 status updated
   (PR A + PR B delivered, only PR C — CC SDK — deferred); broken cross-repo `#pdfs-via-doc-pipeline-engine` anchor in the Future bullet 
  repointed; `validated_links` date refreshed.
  - **ADR cleanup** — ADR-0002: nav claim "ADRs (0001, 0002)" → "ADRs (via `adr/index.md`)"; Option 4 narrative `v2_normalize` →
  `local_normalize`. ADR-0004 Consequences: `V1`/`V2` → `anthropic_sdk`/`local` (post-ADR-0003 state). ADR-0005 row in `adr/index.md`: `Proposed
  (2026-05-25)` → `Accepted (2026-05-26)` (matches the ADR file's own status).
  - **README** — `make install_v2_nlp` → `make install_local_nlp`; surrounding "V1 stages" / "V2 NER entities" wording updated to canonical leg
  names per ADR-0003.
  - **Hygiene** — `mkdocs.yaml` annotates `docstrings.md` as a build artifact (gitignored, deploy-time generated); `.markdownlint-cli2.jsonc`
  whitelists `<details>` / `<summary>` in MD033 so the new `<details>` embed pattern lints clean.

  ## Test plan

  - [ ] CI: \`markdownlint-cli2\` workflow green (MD033 allowlist now covers `<details>` and `<summary>`)
  - [ ] CI: \`CodeQL\` and \`CodeFactor\` green
  - [ ] \`make docs\` (mkdocs build) succeeds locally — no broken nav entries, no missing files
  - [ ] Visual: open \`docs/architecture.md\` on github.com — confirm \`<details>\` is collapsed by default, expands to show the SVG at the new
  \`docs/assets/images/\` path
  - [ ] Visual: SVG renders in both light and dark mode; lane labels hide below 600 px rendered width
  - [ ] Cross-link check: PDF-roundtrip bullet in \`docs/roadmap.md\` § Future now points at the sibling repo's \`docs/roadmap.md\` (the previous
  \`#pdfs-via-doc-pipeline-engine\` anchor never existed)
  - [ ] \`docs/adr/index.md\` ADR-0005 row matches the ADR file's \`Status\` header (both \`Accepted (2026-05-26)\`)
  - [ ] No \`v1\`/\`v2\` residue in forward-facing docs (historical run-1/2/3 snapshots intentionally preserve old wording)

  Generated with Claude <noreply@anthropic.com>