### PR TITLE
docs(roadmap): record post-Extract order constraint for pseudonymize-text

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,4 +162,4 @@ Evaluation harnesses and quality gates.
 - Graph-RAG
 - Certification packages (ISO 13485, IEC 62304, 21 CFR Part 11)
 - CAD/LOB ingest
-- PDF roundtrip pseudonymization — pair Extract with [`utils-pseudonomyze-text`](https://github.com/qte77/pseudonymize-text) and rebuild a redacted PDF that preserves layout. Today only the extracted text can be tokenized (`pseudonymize` defers PDF input per its [roadmap](https://github.com/qte77/pseudonymize-text/blob/main/docs/roadmap.md)); the original PDF cannot be reassembled.
+- PDF roundtrip pseudonymization — pair Extract with [`utils-pseudonomyze-text`](https://github.com/qte77/pseudonymize-text) and rebuild a redacted PDF that preserves layout. Today only the extracted text can be tokenized (`pseudonymize` defers PDF/Office/image input per its [roadmap](https://github.com/qte77/pseudonymize-text/blob/main/docs/roadmap.md)), so for mixed-format inboxes the only viable order is `Discover → Extract → Pseudonymize → Analyze`; the original PDF cannot be reassembled. Redactor-default decision tracked in [issue #107](https://github.com/qte77/doc-pipeline-engine/issues/107).


### PR DESCRIPTION
## Summary

- pseudonymize-text 0.2.0 explicitly defers PDF/Office/image input, so for a mixed-format inbox (mail + text + docx + native PDF + scanned PDF + images) the only viable order is \`Discover → Extract → Pseudonymize → Analyze\`.
- One-line tweak to the roadmap §Future entry that already names \`utils-pseudonomyze-text\` — adds the order constraint inline and links #107 as the home for the redactor-default decision.
- Companion: workflow-constraint comment posted on #107 (https://github.com/qte77/doc-pipeline-engine/issues/107#issuecomment-4588515111).

No code change, no contract change.

## Test plan

- [ ] markdownlint passes on \`docs/roadmap.md\`
- [ ] link check passes (new link is the existing issue URL)
- [ ] CodeQL / CI checks green
- [ ] roadmap §Future line still reads cleanly in rendered preview

Refs: #107

Generated with Claude <noreply@anthropic.com>