### PR TITLE
fix(lint): allow <details>/<summary> in markdownlint so make lint_md passes

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -6,7 +6,9 @@
     // Line length: disabled globally (per the frontmatter-convention rule import).
     "MD013": false,
     // First-line H1 satisfied by YAML frontmatter `title:` field.
-    "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" }
+    "MD041": { "front_matter_title": "^\\s*title\\s*[:=]" },
+    // Allow GitHub-flavored collapsible blocks (docs/architecture.md overview).
+    "MD033": { "allowed_elements": ["details", "summary"] }
   },
   "globs": [
     "**/*.md"


### PR DESCRIPTION
## What

`make lint_md` (and the centralized lint CI) currently fails on `main`:

```text
docs/architecture.md:10:1 error MD033/no-inline-html Inline HTML [Element: details]
docs/architecture.md:11:1 error MD033/no-inline-html Inline HTML [Element: summary]
```

`docs/architecture.md` (since #109) wraps the architecture-overview SVG in a GitHub-flavored `<details>`/`<summary>` collapsible. That's an intentional UX choice, but MD033 (`no-inline-html`) rejects raw HTML by default.

## Fix

Allow exactly those two elements in `.markdownlint-cli2.jsonc`:

```jsonc
"MD033": { "allowed_elements": ["details", "summary"] }
```

This follows the project's own rule — configure markdownlint in the config file, no inline `<!-- markdownlint-disable -->` — and preserves the collapsible rather than stripping it.

`make lint_md` → **0 errors** (36 files) after the change. Unblocks lint CI on `main` and on every open PR branched from it (e.g. #112).

Generated with Claude <noreply@anthropic.com>
