### PR TITLE
docs(architecture): document supported input formats (Kreuzberg + SVG)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,6 +50,19 @@ Reserved stages (stub contracts, wired later):
 - CheckOutputConformance → FormatConformance
 - Format definitions → InputFormat, OutputFormat
 
+## Supported input formats
+
+The Extract stage delegates to Kreuzberg. Format support follows from
+Kreuzberg's adapters:
+
+| Format | Status | Path |
+| --- | --- | --- |
+| PDF | supported | pypdfium2 |
+| DOCX, XLSX, PPTX | supported | Kreuzberg native |
+| TXT, MD, HTML | supported | Kreuzberg native |
+| PNG, JPG, TIFF | supported | Tesseract OCR (requires `make install_image_ocr`) |
+| **SVG** | **not supported** | Vector XML, no OCR/text path. Pre-rasterize to PNG if needed. |
+
 ## Package layout
 
 ```text

--- a/src/doc_pipeline_engine/stages/extract.py
+++ b/src/doc_pipeline_engine/stages/extract.py
@@ -14,6 +14,9 @@ the extra installed raises a clear error.
 The unit tests substitute ``_extract_file_sync`` and ``_kreuzberg_version``
 via monkeypatch so they run without the extra. Real-Kreuzberg behavior is
 covered by tests marked ``integration``.
+
+Supported input formats: see docs/architecture.md → "Supported input formats".
+SVG is not supported.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## What

Adds a **Supported input formats** section to `docs/architecture.md` documenting what the Kreuzberg-backed Extract stage handles, plus a pointer from the extract-stage docstring.

| Format | Status | Path |
| --- | --- | --- |
| PDF | supported | pypdfium2 |
| DOCX, XLSX, PPTX | supported | Kreuzberg native |
| TXT, MD, HTML | supported | Kreuzberg native |
| PNG, JPG, TIFF | supported | Tesseract OCR (`make install_image_ocr`) |
| **SVG** | **not supported** | pre-rasterize to PNG |

## Why

Salvaged from an abandoned local WIP branch (`feat/external-anthropic-and-cc-cli`, whose committed work is already on `main` via #54/#61). The table is genuinely useful and absent from `main`'s architecture.md. The WIP's stale "SVG samples in `samples/mech-elec-cert/`" claim was **dropped** — that dir currently holds only raster `.jpg` samples.

## Notes

- `make lint_md` surfaces the 2 pre-existing `docs/architecture.md` `<details>`/`<summary>` MD033 errors (fixed by #113); this PR adds **no** new lint errors.

Generated with Claude <noreply@anthropic.com>
