### PR TITLE
chore(dependabot): ignore kreuzberg >=4.8 (ELv2 boundary, ADR-0005)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,4 +6,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # kreuzberg v4.8+ relicensed from MIT to Elastic License v2 (source-available,
+    # not Apache-compatible). ADR-0005 pins kreuzberg<4.8 to stay on the MIT line;
+    # ELv2 ships only behind the opt-in [kreuzberg-elv2] extra. Ignore >=4.8 so
+    # dependabot stops proposing to cross that licence boundary (e.g. PR #111:
+    # widening <4.8 -> <4.10). See docs/adr/0005-kreuzberg-elv2-license-boundary.md.
+    ignore:
+      - dependency-name: "kreuzberg"
+        versions: [">=4.8"]
 ...


### PR DESCRIPTION
## What

Adds a dependabot `ignore` for `kreuzberg >=4.8` in `.github/dependabot.yaml`, with an inline comment explaining the reason.

## Why

`kreuzberg` v4.8+ relicensed from MIT to **Elastic License v2** (source-available, not Apache-compatible). **ADR-0005** deliberately pins `kreuzberg<4.8` to keep the default install on the MIT line; ELv2 ships only behind the opt-in `[kreuzberg-elv2]` extra.

Without this ignore, dependabot keeps proposing to widen the constraint (e.g. **#111**: `<4.8` → `<4.10`), which would pull ELv2 into the default install. This stops the recurrence at the source.

**Supersedes #111** — that PR should be closed.

Generated with Claude <noreply@anthropic.com>
