### PR TITLE
feat(agents): AGENTS.md-only standard — symlink, self-contained content, plugin fix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,9 +13,9 @@
   },
   "enabledPlugins": {
     "context7@claude-plugins-official": true,
-    "python-dev@qte77-claude-code-utils": true,
-    "commit-helper@qte77-claude-code-utils": true,
-    "docs-governance@qte77-claude-code-utils": true
+    "python-dev@qte77/claude-code-plugins": true,
+    "commit-helper@qte77/claude-code-plugins": true,
+    "docs-governance@qte77/claude-code-plugins": true
   },
   "permissions": {
     "allow": [

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,28 @@ agents.** For technical workflows and coding standards, see
 [CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
 [README.md](README.md).
 
-**External References:**
+**External References** (human contributors): [CONTRIBUTING.md](CONTRIBUTING.md) | [AGENT_REQUESTS.md](AGENT_REQUESTS.md) | [AGENT_LEARNINGS.md](AGENT_LEARNINGS.md)
 
-- @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
-- @AGENT_REQUESTS.md - Escalation and human collaboration
-- @AGENT_LEARNINGS.md - Pattern discovery and knowledge sharing
+## Key Commands
+
+| Command | Purpose |
+| --- | --- |
+| `make install` | `uv sync` — install dev dependencies |
+| `make test` | Full pytest suite |
+| `make test_rerun` | Rerun only failed tests (fast TDD iteration) |
+| `make lint` | Ruff check on Python sources |
+| `make validate` | Pre-commit gate: lint + test + lint_md + lint_links |
+
+## Code Conventions
+
+- **Imports**: absolute (`from doc_pipeline_engine.module import X`)
+- **Comments**: default to none; add `# Reason:` only when the *why* is non-obvious
+- **Tests**: mirror `src/` layout under `tests/`; new functionality requires tests
+- **Commits**: Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`)
+
+## Escalation
+
+Write to `AGENT_REQUESTS.md` when: user instructions conflict with safety practices, rules contradict each other, required information is missing, or actions would significantly change project architecture.
 
 ## Claude Code Infrastructure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,7 +20,7 @@ exclude = [
   "^https?://localhost",
 
   # --- Timeout-prone in CI ---
-  "^https?://www\.gnu\.org",
+  "^https?://www\\.gnu\\.org",
 
   # --- Not yet released ---
   # v0.1.0 release tag URLs in CHANGELOG once tag is cut

--- a/lychee.toml
+++ b/lychee.toml
@@ -19,6 +19,9 @@ exclude = [
   # --- Non-routable / local ---
   "^https?://localhost",
 
+  # --- Timeout-prone in CI ---
+  "^https?://www\.gnu\.org",
+
   # --- Not yet released ---
   # v0.1.0 release tag URLs in CHANGELOG once tag is cut
   "^https://github\\.com/qte77/doc-pipeline-engine/releases/tag/v",


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: symlink to `AGENTS.md` (Claude Code bridge; Codex/Gemini read AGENTS.md natively)
- `AGENTS.md`: replace `@import` refs with inline Key Commands, Code Conventions, Escalation sections (self-contained for non-Claude agents)
- `.claude/settings.json`: fix stale plugin marketplace refs (`qte77-claude-code-utils` → `qte77/claude-code-plugins`)

## Test plan

- [ ] Confirm `CLAUDE.md` is a symlink: `file CLAUDE.md`
- [ ] Confirm `AGENTS.md` has no `@` import lines
- [ ] Confirm `.claude/settings.json` plugin keys use `qte77/claude-code-plugins`

Generated with Claude <noreply@anthropic.com>