### PR TITLE
feat(stream): §0.3.0 NDJSON stream interface over the runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@
 .PHONY: \
 	install install_models install_image_ocr install_local_nlp install_v2_nlp \
 	setup_uv setup_dev setup_claude_code setup_npm_tools setup_lychee \
-	test test_contracts test_rerun test_fix_snapshots \
+	test test_contracts test_stream test_rerun test_fix_snapshots \
 	lint lint_md lint_links validate clean help \
-	docs docs_serve docs_index docs_contracts
+	docs docs_serve docs_index docs_contracts \
+	stream
 .DEFAULT_GOAL := help
 
 VERBOSE ?=
@@ -70,6 +71,16 @@ install_local_nlp:  ## Use case: `local` leg with NER entities — installs spaC
 install_v2_nlp: install_local_nlp  ## Deprecated alias for install_local_nlp; will be removed in §0.5.0
 
 install_models: install_local_nlp  ## Deprecated alias for install_local_nlp; will be removed in §0.5.0
+
+
+# MARK: STREAM
+
+
+stream:  ## Run NDJSON stream pipeline (usage: SEED='{"root":"."}' make stream STAGES=discover)
+	echo '$(SEED)' | uv run doc-pipeline $(STAGES)
+
+test_stream:  ## Run stream interface tests only
+	uv run pytest tests/test_stream.py -v
 
 
 # MARK: QUALITY

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .PHONY: \
 	install install_models install_image_ocr install_local_nlp install_v2_nlp \
 	setup_uv setup_dev setup_claude_code setup_npm_tools setup_lychee \
-	test test_contracts test_stream test_rerun test_fix_snapshots \
+	test test_contracts test_stream test_adapters test_rerun test_fix_snapshots \
 	lint lint_md lint_links validate clean help \
 	docs docs_serve docs_index docs_contracts \
 	stream
@@ -81,6 +81,9 @@ stream:  ## Run NDJSON stream pipeline (usage: SEED='{"root":"."}' make stream S
 
 test_stream:  ## Run stream interface tests only
 	uv run pytest tests/test_stream.py -v
+
+test_adapters:  ## Run adapter registry and implementation tests only
+	uv run pytest tests/test_adapters.py -v
 
 
 # MARK: QUALITY

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,6 +138,8 @@ Real extraction backends plugged into the runner/stream.
 
 ## 0.5.0 — Domain packs
 
+**Status**: done
+
 Pluggable per-domain config: policies, prompts, thresholds, input/output formats.
 
 **Goals**:
@@ -148,6 +150,8 @@ Pluggable per-domain config: policies, prompts, thresholds, input/output formats
 - Data-locality policies (local-only, claude-api-extracted-only, cloud-redacted)
 
 ## 0.6.0 — Eval
+
+**Status**: done (gates + failure tests; RAGAs/TruLens/DeepEval harness wrappers and orchestration bench P1–P4 deferred)
 
 Evaluation harnesses and quality gates.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 title: Roadmap
 purpose: Versioned milestones (0.1 → 0.6+) with status, scope, and reasoning per release
 created: 2026-04-23
-updated: 2026-05-28
+updated: 2026-06-18
 validated_links: 2026-05-31
 category: requirements
 ---
@@ -97,6 +97,8 @@ Two-step refactor:
 
 ## 0.3.0 — Stream
 
+**Status**: done
+
 NDJSON (newline-delimited JSON) interface over the runner. Enables CLI composition, audit logging, and IPC.
 
 **Why now**: runner proves in-process flow; stream wraps it for pipes, logging, and external consumers. Falls out naturally from 0.2.0.
@@ -115,6 +117,8 @@ NDJSON (newline-delimited JSON) interface over the runner. Enables CLI compositi
 - Works with `jq`, any language, any consumer (polyforge, office-polyforge)
 
 ## 0.4.0 — Adapters
+
+**Status**: done
 
 Real extraction backends plugged into the runner/stream.
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -20,7 +20,7 @@ exclude = [
   "^https?://localhost",
 
   # --- Timeout-prone in CI ---
-  "^https?://www\.gnu\.org",
+  "^https?://www\\.gnu\\.org",
 
   # --- Not yet released ---
   # v0.1.0 release tag URLs in CHANGELOG once tag is cut

--- a/lychee.toml
+++ b/lychee.toml
@@ -19,6 +19,9 @@ exclude = [
   # --- Non-routable / local ---
   "^https?://localhost",
 
+  # --- Timeout-prone in CI ---
+  "^https?://www\.gnu\.org",
+
   # --- Not yet released ---
   # v0.1.0 release tag URLs in CHANGELOG once tag is cut
   "^https://github\\.com/qte77/doc-pipeline-engine/releases/tag/v",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,9 @@ docs = [
   "mkdocs-autorefs>=1.0",
 ]
 
+[project.scripts]
+doc-pipeline = "doc_pipeline_engine.stream:main"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/doc_pipeline_engine/base/adapter.py
+++ b/src/doc_pipeline_engine/base/adapter.py
@@ -26,11 +26,25 @@ from pathlib import Path
 from typing import Any
 
 
+Locality = str
+"""Data locality of an adapter: ``"local"`` (on-device) or ``"api"`` (external LLM call)."""
+
+
 class AdapterBase(ABC):
-    """Base class every extraction backend implements."""
+    """Base class every extraction backend implements.
+
+    Class attributes:
+        name: Short adapter identifier registered in the adapter registry.
+        version: Adapter implementation version string.
+        locality: Data locality — ``"local"`` for on-device processing,
+            ``"api"`` for adapters that call an external LLM API.
+            Used by :class:`~doc_pipeline_engine.base.gates.PolicyGate` to
+            enforce data-locality policies without a hardcoded allowlist.
+    """
 
     name: str
     version: str
+    locality: Locality = "local"
 
     @abstractmethod
     def extract(self, manifest_file: dict[str, Any], source_root: Path) -> dict[str, Any]:

--- a/src/doc_pipeline_engine/base/adapter.py
+++ b/src/doc_pipeline_engine/base/adapter.py
@@ -5,14 +5,24 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
-"""Adapter ABC for extraction backends.
+"""Adapter ABC and registry for extraction backends.
 
-An adapter consumes a single file entry from a `DiscoveryManifest` and emits
-an `ExtractionBundle`. Concrete adapters live in `stages/` (e.g. Kreuzberg).
+An adapter consumes one DiscoveryManifest file entry and emits an
+ExtractionBundle dict. Concrete adapters register themselves via
+:func:`register`; callers retrieve them with :func:`get`.
+
+Built-in adapters (lazy-imported on first use):
+
+- ``kreuzberg``   — Kreuzberg library (opt-in extra)
+- ``claude_cli``  — Claude Code CLI headless one-shot
+- ``docling``     — Docling (stub; not yet implemented)
+- ``glm_ocr``     — GLM-OCR (stub; not yet implemented)
+- ``paddle_ocr``  — PaddleOCR-VL (stub; not yet implemented)
 """
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any
 
 
@@ -23,6 +33,57 @@ class AdapterBase(ABC):
     version: str
 
     @abstractmethod
-    def extract(self, manifest_file: dict[str, Any]) -> dict[str, Any]:
-        """Convert one DiscoveryManifest file entry to an ExtractionBundle dict."""
+    def extract(self, manifest_file: dict[str, Any], source_root: Path) -> dict[str, Any]:
+        """Convert one DiscoveryManifest file entry to an ExtractionBundle dict.
+
+        Args:
+            manifest_file: One entry from ``DiscoveryManifest.files``.
+            source_root: Absolute path to the folder that was discovered.
+
+        Returns:
+            A dict that validates against the ``ExtractionBundle`` contract.
+        """
         ...
+
+
+_REGISTRY: dict[str, AdapterBase] = {}
+
+_BUILTIN: dict[str, str] = {
+    "kreuzberg": "doc_pipeline_engine.stages._adapters.kreuzberg",
+    "claude_cli": "doc_pipeline_engine.stages._adapters.claude_cli",
+    "docling": "doc_pipeline_engine.stages._adapters.docling",
+    "glm_ocr": "doc_pipeline_engine.stages._adapters.glm_ocr",
+    "paddle_ocr": "doc_pipeline_engine.stages._adapters.paddle_ocr",
+}
+
+
+def register(adapter: AdapterBase) -> None:
+    """Register an adapter instance under its ``name``."""
+    _REGISTRY[adapter.name] = adapter
+
+
+def get(name: str) -> AdapterBase:
+    """Return the named adapter, lazy-loading built-ins on first access.
+
+    Args:
+        name: Adapter name (e.g. ``"kreuzberg"``).
+
+    Returns:
+        The registered :class:`AdapterBase` instance.
+
+    Raises:
+        KeyError: if ``name`` is not registered and not a known built-in.
+    """
+    if name not in _REGISTRY:
+        if name not in _BUILTIN:
+            known = sorted(set(_REGISTRY) | set(_BUILTIN))
+            raise KeyError(f"Unknown adapter {name!r}. Known: {known}")
+        import importlib
+
+        importlib.import_module(_BUILTIN[name])
+    return _REGISTRY[name]
+
+
+def available() -> list[str]:
+    """Return names of all registered adapters."""
+    return sorted(_REGISTRY)

--- a/src/doc_pipeline_engine/base/gates.py
+++ b/src/doc_pipeline_engine/base/gates.py
@@ -95,27 +95,14 @@ def _safe_get_input(fmt_id: str) -> Any:
         return None
 
 
-_POLICY_ALLOWED_ADAPTERS: dict[str, set[str]] = {
-    "local-only": {"kreuzberg", "docling", "glm_ocr", "paddle_ocr"},
-    "claude-api-extracted-only": {
-        "kreuzberg",
-        "claude_cli",
-        "docling",
-        "glm_ocr",
-        "paddle_ocr",
-    },
-    "cloud-redacted": {
-        "kreuzberg",
-        "claude_cli",
-        "docling",
-        "glm_ocr",
-        "paddle_ocr",
-    },
-}
-
-
 class PolicyGate:
     """Reject adapter/pack combinations that violate data-locality policy (F5).
+
+    Policy enforcement is derived from the adapter's ``locality`` attribute
+    (``"local"`` or ``"api"``) — no hardcoded allowlist needed.
+
+    - ``local-only`` — only ``locality="local"`` adapters permitted.
+    - ``claude-api-extracted-only`` / ``cloud-redacted`` — all localities permitted.
 
     Args:
         pack_name: Domain pack name used to look up the policy.
@@ -133,16 +120,25 @@ class PolicyGate:
         Raises:
             GateError: if the adapter is not permitted under the pack's policy.
         """
+        from doc_pipeline_engine.base.adapter import get as get_adapter
         from doc_pipeline_engine.domain import get as get_pack
 
         pack = get_pack(self._pack_name)
-        allowed = _POLICY_ALLOWED_ADAPTERS.get(pack.policy, set())
-        if adapter_name not in allowed:
+        if pack.policy != "local-only":
+            return
+
+        try:
+            adapter = get_adapter(adapter_name)
+            locality = adapter.locality
+        except KeyError:
+            locality = "unknown"
+
+        if locality != "local":
             raise GateError(
                 "F5-policy-violation",
-                f"adapter={adapter_name!r} is not permitted under policy "
-                f"{pack.policy!r} of pack {self._pack_name!r}. "
-                f"Permitted adapters: {sorted(allowed)}",
+                f"adapter={adapter_name!r} (locality={locality!r}) is not permitted "
+                f"under policy {pack.policy!r} of pack {self._pack_name!r}. "
+                f"Only adapters with locality='local' are allowed.",
             )
 
 

--- a/src/doc_pipeline_engine/base/gates.py
+++ b/src/doc_pipeline_engine/base/gates.py
@@ -1,0 +1,179 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Pipeline quality gates.
+
+Gates are callable checks inserted between stages. Each gate raises
+:class:`GateError` when its condition is violated; callers treat a
+``GateError`` as a halting failure (equivalent to a ``PipelineError``).
+
+Built-in gates:
+
+- :class:`FormatGate` — rejects files whose type is not in the domain pack's
+  accepted input formats (failure mode F11).
+- :class:`PolicyGate` — rejects adapter/pack combinations that violate the
+  pack's data-locality policy (failure mode F5).
+- :class:`ConfidenceGate` — rejects ExtractionBundles below the pack's
+  extraction confidence threshold (failure mode F2 partial).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class GateError(Exception):
+    """Raised when a pipeline gate condition is violated.
+
+    Attributes:
+        gate: Name of the gate that fired.
+        detail: Human-readable explanation.
+    """
+
+    def __init__(self, gate: str, detail: str) -> None:
+        self.gate = gate
+        self.detail = detail
+        super().__init__(f"gate={gate!r}: {detail}")
+
+
+class FormatGate:
+    """Reject files whose type is not accepted by the domain pack (F11).
+
+    Args:
+        pack_name: Domain pack name used to look up accepted input formats.
+    """
+
+    def __init__(self, pack_name: str) -> None:
+        self._pack_name = pack_name
+
+    def check(self, manifest_file: dict[str, Any]) -> None:
+        """Raise GateError if file_type is not in the pack's input formats.
+
+        Args:
+            manifest_file: One entry from ``DiscoveryManifest.files``.
+
+        Raises:
+            GateError: if the file type is not accepted by the pack.
+        """
+        from doc_pipeline_engine.domain import get as get_pack
+        from doc_pipeline_engine.domain.formats import get_input
+
+        pack = get_pack(self._pack_name)
+        file_type = manifest_file.get("file_type", "")
+
+        for fmt_id in pack.input_format_ids:
+            try:
+                fmt = get_input(fmt_id)
+            except KeyError:
+                continue
+            if file_type in fmt.file_types:
+                return
+
+        accepted = sorted(
+            ext
+            for fmt_id in pack.input_format_ids
+            for fmt in [_safe_get_input(fmt_id)]
+            if fmt
+            for ext in fmt.file_types
+        )
+        raise GateError(
+            "F11-format-miss",
+            f"file_type={file_type!r} not accepted by pack {self._pack_name!r}. "
+            f"Accepted: {accepted}",
+        )
+
+
+def _safe_get_input(fmt_id: str) -> Any:
+    from doc_pipeline_engine.domain.formats import get_input
+
+    try:
+        return get_input(fmt_id)
+    except KeyError:
+        return None
+
+
+_POLICY_ALLOWED_ADAPTERS: dict[str, set[str]] = {
+    "local-only": {"kreuzberg", "docling", "glm_ocr", "paddle_ocr"},
+    "claude-api-extracted-only": {
+        "kreuzberg",
+        "claude_cli",
+        "docling",
+        "glm_ocr",
+        "paddle_ocr",
+    },
+    "cloud-redacted": {
+        "kreuzberg",
+        "claude_cli",
+        "docling",
+        "glm_ocr",
+        "paddle_ocr",
+    },
+}
+
+
+class PolicyGate:
+    """Reject adapter/pack combinations that violate data-locality policy (F5).
+
+    Args:
+        pack_name: Domain pack name used to look up the policy.
+    """
+
+    def __init__(self, pack_name: str) -> None:
+        self._pack_name = pack_name
+
+    def check(self, adapter_name: str) -> None:
+        """Raise GateError if the adapter violates the pack's policy.
+
+        Args:
+            adapter_name: Name of the adapter about to be used (e.g. ``"claude_cli"``).
+
+        Raises:
+            GateError: if the adapter is not permitted under the pack's policy.
+        """
+        from doc_pipeline_engine.domain import get as get_pack
+
+        pack = get_pack(self._pack_name)
+        allowed = _POLICY_ALLOWED_ADAPTERS.get(pack.policy, set())
+        if adapter_name not in allowed:
+            raise GateError(
+                "F5-policy-violation",
+                f"adapter={adapter_name!r} is not permitted under policy "
+                f"{pack.policy!r} of pack {self._pack_name!r}. "
+                f"Permitted adapters: {sorted(allowed)}",
+            )
+
+
+class ConfidenceGate:
+    """Reject ExtractionBundles below the pack's confidence threshold (F2 partial).
+
+    Args:
+        pack_name: Domain pack name used to look up the threshold.
+    """
+
+    def __init__(self, pack_name: str) -> None:
+        self._pack_name = pack_name
+
+    def check(self, extraction_bundle: dict[str, Any]) -> None:
+        """Raise GateError if bundle confidence is below pack threshold.
+
+        Args:
+            extraction_bundle: ExtractionBundle dict output from an adapter.
+
+        Raises:
+            GateError: if confidence is present and below the threshold.
+        """
+        from doc_pipeline_engine.domain import get as get_pack
+
+        pack = get_pack(self._pack_name)
+        confidence = extraction_bundle.get("confidence")
+        if confidence is None:
+            return
+        if confidence < pack.extraction_confidence_threshold:
+            raise GateError(
+                "G-extract-confidence",
+                f"confidence={confidence} is below pack threshold "
+                f"{pack.extraction_confidence_threshold} for pack {self._pack_name!r}",
+            )

--- a/src/doc_pipeline_engine/domain/__init__.py
+++ b/src/doc_pipeline_engine/domain/__init__.py
@@ -1,0 +1,93 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Domain pack registry and DomainPack definition.
+
+A domain pack is the pluggable per-domain configuration: policies, prompts,
+extraction thresholds, and the input/output formats the domain supports.
+
+Built-in packs (lazy-loaded on first access):
+
+- ``generic``              — light pilot, fully wired for §0.5
+- ``mech-elec-cert``       — stub
+- ``med-research-patents`` — stub
+
+Usage::
+
+    from doc_pipeline_engine.domain import get
+
+    pack = get("generic")
+    print(pack.policy)          # "local-only" | "claude-api-extracted-only" | "cloud-redacted"
+    print(pack.input_format_ids) # ["generic/text", "generic/pdf"]
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+Policy = Literal["local-only", "claude-api-extracted-only", "cloud-redacted"]
+
+_REGISTRY: dict[str, "DomainPack"] = {}
+
+_BUILTIN: dict[str, str] = {
+    "generic": "doc_pipeline_engine.domain._pack_generic",
+    "mech-elec-cert": "doc_pipeline_engine.domain._pack_mech_elec_cert",
+    "med-research-patents": "doc_pipeline_engine.domain._pack_med_research_patents",
+}
+
+
+@dataclass(frozen=True)
+class DomainPack:
+    """Immutable per-domain configuration bundle.
+
+    Attributes:
+        name: Short pack identifier (e.g. ``"generic"``).
+        policy: Default data-locality policy for this domain.
+        input_format_ids: Format IDs this pack accepts (must exist in the format registry).
+        output_format_ids: Format IDs this pack can emit.
+        extraction_confidence_threshold: Minimum adapter confidence accepted by gate G_extract.
+        prompts: Keyed prompt strings injected at each stage.
+    """
+
+    name: str
+    policy: Policy
+    input_format_ids: list[str]
+    output_format_ids: list[str]
+    extraction_confidence_threshold: float = 0.7
+    prompts: dict[str, str] = field(default_factory=dict)
+
+
+def register(pack: DomainPack) -> None:
+    """Register a domain pack under its ``name``."""
+    _REGISTRY[pack.name] = pack
+
+
+def get(name: str) -> DomainPack:
+    """Return the named domain pack, lazy-loading built-ins on first access.
+
+    Args:
+        name: Pack name (e.g. ``"generic"``).
+
+    Returns:
+        The :class:`DomainPack` instance.
+
+    Raises:
+        KeyError: if ``name`` is not registered and not a known built-in.
+    """
+    if name not in _REGISTRY:
+        if name not in _BUILTIN:
+            known = sorted(set(_REGISTRY) | set(_BUILTIN))
+            raise KeyError(f"Unknown domain pack {name!r}. Known: {known}")
+        import importlib
+
+        importlib.import_module(_BUILTIN[name])
+    return _REGISTRY[name]
+
+
+def available() -> list[str]:
+    """Return names of all registered domain packs."""
+    return sorted(_REGISTRY)

--- a/src/doc_pipeline_engine/domain/_pack_generic.py
+++ b/src/doc_pipeline_engine/domain/_pack_generic.py
@@ -1,0 +1,54 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Generic domain pack — light pilot, fully wired for §0.5."""
+from __future__ import annotations
+
+from doc_pipeline_engine.domain import DomainPack, register
+from doc_pipeline_engine.domain.formats import register_input, register_output
+from doc_pipeline_engine.models.input_format import InputFormat
+from doc_pipeline_engine.models.output_format import OutputFormat
+
+_INPUT_FORMATS = [
+    InputFormat(id="generic/text", version="0.1.0", file_types=["txt", "md"]),
+    InputFormat(id="generic/pdf", version="0.1.0", file_types=["pdf"]),
+    InputFormat(
+        id="generic/office",
+        version="0.1.0",
+        file_types=["docx", "xlsx", "pptx"],
+    ),
+    InputFormat(
+        id="generic/image",
+        version="0.1.0",
+        file_types=["png", "jpg", "jpeg", "tiff", "bmp"],
+    ),
+]
+
+_OUTPUT_FORMATS = [
+    OutputFormat(id="generic/quick-summary", version="0.1.0", tier="quick"),
+    OutputFormat(id="generic/comprehensive-report", version="0.1.0", tier="comprehensive"),
+]
+
+for _fmt in _INPUT_FORMATS:
+    register_input(_fmt)
+for _fmt in _OUTPUT_FORMATS:
+    register_output(_fmt)
+
+register(
+    DomainPack(
+        name="generic",
+        policy="claude-api-extracted-only",
+        input_format_ids=[f.id for f in _INPUT_FORMATS],
+        output_format_ids=[f.id for f in _OUTPUT_FORMATS],
+        extraction_confidence_threshold=0.7,
+        prompts={
+            "normalize": "Normalize this extracted text into clean markdown. Preserve headings, lists, and tables. Remove headers, footers, and page numbers.",
+            "analyze": "Analyze the document and identify its main claims, key entities, and section structure.",
+            "draft": "Write a concise quick-tier summary (3 sentences max) capturing the document's gist.",
+        },
+    )
+)

--- a/src/doc_pipeline_engine/domain/_pack_mech_elec_cert.py
+++ b/src/doc_pipeline_engine/domain/_pack_mech_elec_cert.py
@@ -1,0 +1,22 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Mechanical / electrical certification domain pack — declared stub for §0.5."""
+from __future__ import annotations
+
+from doc_pipeline_engine.domain import DomainPack, register
+
+register(
+    DomainPack(
+        name="mech-elec-cert",
+        policy="local-only",
+        input_format_ids=[],
+        output_format_ids=[],
+        extraction_confidence_threshold=0.85,
+        prompts={},
+    )
+)

--- a/src/doc_pipeline_engine/domain/_pack_med_research_patents.py
+++ b/src/doc_pipeline_engine/domain/_pack_med_research_patents.py
@@ -1,0 +1,22 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Medical / research / patents domain pack — declared stub for §0.5."""
+from __future__ import annotations
+
+from doc_pipeline_engine.domain import DomainPack, register
+
+register(
+    DomainPack(
+        name="med-research-patents",
+        policy="cloud-redacted",
+        input_format_ids=[],
+        output_format_ids=[],
+        extraction_confidence_threshold=0.9,
+        prompts={},
+    )
+)

--- a/src/doc_pipeline_engine/domain/formats.py
+++ b/src/doc_pipeline_engine/domain/formats.py
@@ -1,0 +1,61 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Format registry — maps FormatId strings to InputFormat / OutputFormat instances.
+
+Packs declare format IDs; the registry holds the canonical definitions.
+The registry is populated when domain pack modules are imported.
+"""
+from __future__ import annotations
+
+from doc_pipeline_engine.models.input_format import InputFormat
+from doc_pipeline_engine.models.output_format import OutputFormat
+
+_INPUT: dict[str, InputFormat] = {}
+_OUTPUT: dict[str, OutputFormat] = {}
+
+
+def register_input(fmt: InputFormat) -> None:
+    """Register an input format definition."""
+    _INPUT[fmt.id] = fmt
+
+
+def register_output(fmt: OutputFormat) -> None:
+    """Register an output format definition."""
+    _OUTPUT[fmt.id] = fmt
+
+
+def get_input(format_id: str) -> InputFormat:
+    """Return the named InputFormat.
+
+    Raises:
+        KeyError: if not registered.
+    """
+    if format_id not in _INPUT:
+        raise KeyError(f"Unknown input format {format_id!r}. Known: {sorted(_INPUT)}")
+    return _INPUT[format_id]
+
+
+def get_output(format_id: str) -> OutputFormat:
+    """Return the named OutputFormat.
+
+    Raises:
+        KeyError: if not registered.
+    """
+    if format_id not in _OUTPUT:
+        raise KeyError(f"Unknown output format {format_id!r}. Known: {sorted(_OUTPUT)}")
+    return _OUTPUT[format_id]
+
+
+def available_inputs() -> list[str]:
+    """Return sorted list of registered input format IDs."""
+    return sorted(_INPUT)
+
+
+def available_outputs() -> list[str]:
+    """Return sorted list of registered output format IDs."""
+    return sorted(_OUTPUT)

--- a/src/doc_pipeline_engine/stages/_adapters/__init__.py
+++ b/src/doc_pipeline_engine/stages/_adapters/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Concrete extraction adapter implementations."""

--- a/src/doc_pipeline_engine/stages/_adapters/claude_cli.py
+++ b/src/doc_pipeline_engine/stages/_adapters/claude_cli.py
@@ -1,0 +1,103 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Claude Code CLI adapter — headless one-shot extraction via ``claude --print``."""
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+ADAPTER_NAME = "claude_cli"
+ADAPTER_VERSION = "0.1.0"
+_DEFAULT_MODEL = "claude-opus-4-8"
+_PROMPT = (
+    "Extract the full text content of this document. "
+    "Output only the plain-text content — no commentary, no markdown, no metadata."
+)
+
+
+class ClaudeCliAdapter(AdapterBase):
+    """Extraction backend that shells out to ``claude --print --bare``.
+
+    Requires the Claude Code CLI (``claude``) to be on PATH and a valid
+    session or ANTHROPIC_API_KEY to be configured.
+
+    Args:
+        model: Claude model identifier passed via ``--model``.
+        timeout: Seconds before the subprocess is killed.
+    """
+
+    name = ADAPTER_NAME
+    version = ADAPTER_VERSION
+
+    def __init__(self, model: str = _DEFAULT_MODEL, timeout: int = 120) -> None:
+        self._model = model
+        self._timeout = timeout
+
+    def extract(self, manifest_file: dict[str, Any], source_root: Path) -> dict[str, Any]:
+        """Shell out to ``claude --print --bare`` and parse its JSON envelope.
+
+        Args:
+            manifest_file: One entry from ``DiscoveryManifest.files``.
+            source_root: Absolute path to the discovered folder.
+
+        Returns:
+            ExtractionBundle dict.
+
+        Raises:
+            RuntimeError: if ``claude`` is not on PATH or returns a non-zero exit.
+        """
+        abs_path = source_root / manifest_file["path"]
+        cmd = [
+            "claude",
+            "--print",
+            "--bare",
+            "--output-format", "json",
+            "--model", self._model,
+            "--system-prompt", _PROMPT,
+        ]
+        try:
+            result = subprocess.run(  # noqa: S603
+                cmd,
+                stdin=abs_path.open("rb"),
+                capture_output=True,
+                timeout=self._timeout,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "Claude Code CLI not found. Install it and ensure 'claude' is on PATH."
+            ) from exc
+
+        if result.returncode != 0:
+            stderr = result.stderr.decode(errors="replace")
+            raise RuntimeError(
+                f"claude exited {result.returncode}: {stderr[:500]}"
+            )
+
+        try:
+            envelope = json.loads(result.stdout)
+            text = envelope.get("result", "")
+        except json.JSONDecodeError:
+            # --bare with --output-format json should always be valid; fall back to raw
+            text = result.stdout.decode(errors="replace")
+
+        return {
+            "version": "0.1.0",
+            "source_path": manifest_file["path"],
+            "source_sha256": manifest_file["sha256"],
+            "adapter": {"name": ADAPTER_NAME, "version": ADAPTER_VERSION},
+            "extracted_at": datetime.now(timezone.utc).isoformat(),
+            "content": {"text": text, "layout": []},
+        }
+
+
+register(ClaudeCliAdapter())

--- a/src/doc_pipeline_engine/stages/_adapters/claude_cli.py
+++ b/src/doc_pipeline_engine/stages/_adapters/claude_cli.py
@@ -38,6 +38,7 @@ class ClaudeCliAdapter(AdapterBase):
 
     name = ADAPTER_NAME
     version = ADAPTER_VERSION
+    locality = "api"
 
     def __init__(self, model: str = _DEFAULT_MODEL, timeout: int = 120) -> None:
         self._model = model

--- a/src/doc_pipeline_engine/stages/_adapters/docling.py
+++ b/src/doc_pipeline_engine/stages/_adapters/docling.py
@@ -1,0 +1,28 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Docling adapter stub — not yet implemented."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+
+class DoclingAdapter(AdapterBase):
+    """Stub adapter for IBM Docling (§0.4.0 deferred)."""
+
+    name = "docling"
+    version = "0.0.0"
+
+    def extract(self, manifest_file: dict[str, Any], source_root: Path) -> dict[str, Any]:
+        """Not implemented — raises NotImplementedError."""
+        raise NotImplementedError("DoclingAdapter is not yet implemented (§0.4.0 stub)")
+
+
+register(DoclingAdapter())

--- a/src/doc_pipeline_engine/stages/_adapters/glm_ocr.py
+++ b/src/doc_pipeline_engine/stages/_adapters/glm_ocr.py
@@ -1,0 +1,28 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""GLM-OCR adapter stub — not yet implemented."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+
+class GlmOcrAdapter(AdapterBase):
+    """Stub adapter for GLM-OCR (§0.4.0 deferred)."""
+
+    name = "glm_ocr"
+    version = "0.0.0"
+
+    def extract(self, manifest_file: dict[str, Any], source_root: Path) -> dict[str, Any]:
+        """Not implemented — raises NotImplementedError."""
+        raise NotImplementedError("GlmOcrAdapter is not yet implemented (§0.4.0 stub)")
+
+
+register(GlmOcrAdapter())

--- a/src/doc_pipeline_engine/stages/_adapters/kreuzberg.py
+++ b/src/doc_pipeline_engine/stages/_adapters/kreuzberg.py
@@ -1,0 +1,29 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Kreuzberg adapter — wraps the existing Kreuzberg-backed extract stage."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from doc_pipeline_engine.base.adapter import AdapterBase, register
+from doc_pipeline_engine.stages.extract import extract as _kreuzberg_extract
+
+
+class KreuzbergAdapter(AdapterBase):
+    """Extraction backend using the Kreuzberg library (opt-in extra)."""
+
+    name = "kreuzberg"
+    version = "0.1.0"
+
+    def extract(self, manifest_file: dict[str, Any], source_root: Path) -> dict[str, Any]:
+        """Delegate to the Kreuzberg-backed extract stage function."""
+        return _kreuzberg_extract(manifest_file, source_root)
+
+
+register(KreuzbergAdapter())

--- a/src/doc_pipeline_engine/stages/_adapters/paddle_ocr.py
+++ b/src/doc_pipeline_engine/stages/_adapters/paddle_ocr.py
@@ -1,0 +1,28 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""PaddleOCR-VL adapter stub — not yet implemented."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+
+class PaddleOcrAdapter(AdapterBase):
+    """Stub adapter for PaddleOCR-VL (§0.4.0 deferred)."""
+
+    name = "paddle_ocr"
+    version = "0.0.0"
+
+    def extract(self, manifest_file: dict[str, Any], source_root: Path) -> dict[str, Any]:
+        """Not implemented — raises NotImplementedError."""
+        raise NotImplementedError("PaddleOcrAdapter is not yet implemented (§0.4.0 stub)")
+
+
+register(PaddleOcrAdapter())

--- a/src/doc_pipeline_engine/stream.py
+++ b/src/doc_pipeline_engine/stream.py
@@ -1,0 +1,138 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""NDJSON stream interface over the pipeline runner.
+
+Each stage emits one JSON line to stdout::
+
+    {"stage": "<name>", "contract": "<name>", "output": {...}}
+
+On contract failure a single error line is emitted and the process exits
+with code 1::
+
+    {"stage": "<name>", "contract": "<name>", "error": "<detail>"}
+
+Usage (seed from stdin, output to stdout)::
+
+    echo '{"root": "/data/ingest", "glob": "**/*.pdf"}' | \\
+        python -m doc_pipeline_engine.stream discover
+
+``python -m doc_pipeline_engine.stream`` with no subcommand lists available
+stage names.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+from doc_pipeline_engine.runner import PipelineError, Stage, run
+
+_STAGE_REGISTRY: dict[str, Stage] = {}
+
+
+def _discover_adapter(seed: dict[str, Any]) -> dict[str, Any]:
+    """Unpack seed dict and call discover with typed args."""
+    from pathlib import Path
+
+    from doc_pipeline_engine.stages.discover import discover
+
+    return discover(Path(seed["root"]), seed.get("glob", "**/*"))
+
+
+def _extract_adapter(file_entry: dict[str, Any]) -> dict[str, Any]:
+    """Unpack file_entry dict and call extract with typed args."""
+    from pathlib import Path
+
+    from doc_pipeline_engine.stages.extract import extract
+
+    # file_entry must carry source_root; stream callers embed it in the seed
+    source_root = Path(file_entry.get("source_root", "."))
+    return extract(file_entry, source_root)
+
+
+_ADAPTERS: dict[str, Any] = {
+    "discover": _discover_adapter,
+    "extract": _extract_adapter,
+}
+
+
+def _register(name: str, contract: str) -> None:
+    """Register a stage adapter by name."""
+    if name not in _ADAPTERS:
+        raise KeyError(f"Unknown stage: {name!r}")
+    _STAGE_REGISTRY[name] = (name, _ADAPTERS[name], contract)
+
+
+_KNOWN: dict[str, str] = {
+    "discover": "DiscoveryManifest",
+    "extract": "ExtractionBundle",
+}
+
+
+def _emit(obj: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(obj, default=str) + "\n")
+    sys.stdout.flush()
+
+
+def run_stream(stage_names: list[str], seed: dict[str, Any]) -> int:
+    """Run named stages in order, emitting one NDJSON line per stage.
+
+    Args:
+        stage_names: Ordered list of stage names to execute.
+        seed: Initial input passed to the first stage.
+
+    Returns:
+        Exit code: 0 on success, 1 on contract failure.
+    """
+    stages: list[Stage] = []
+    for name in stage_names:
+        if name not in _KNOWN:
+            _emit({"error": f"Unknown stage: {name!r}. Known: {sorted(_KNOWN)}"})
+            return 1
+        _register(name, _KNOWN[name])
+        stages.append(_STAGE_REGISTRY[name])
+
+    try:
+        outputs = run(stages, seed)
+    except PipelineError as exc:
+        _emit({"stage": exc.stage_name, "contract": exc.contract_name, "error": exc.detail})
+        return 1
+
+    for (name, _fn, contract), output in zip(stages, outputs):
+        _emit({"stage": name, "contract": contract, "output": output})
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: read seed from stdin, stream stage outputs to stdout.
+
+    Args:
+        argv: Argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        Exit code.
+    """
+    args = argv if argv is not None else sys.argv[1:]
+
+    if not args:
+        known = ", ".join(sorted(_KNOWN))
+        sys.stderr.write(f"Usage: doc-pipeline <stage> [<stage> ...]\nKnown stages: {known}\n")
+        return 2
+
+    try:
+        seed = json.loads(sys.stdin.read())
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"Invalid JSON on stdin: {exc}\n")
+        return 2
+
+    return run_stream(list(args), seed)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,159 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for the adapter registry and concrete adapter implementations (§0.4.0)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from doc_pipeline_engine.base.adapter import AdapterBase, available, get, register
+from doc_pipeline_engine.base.contracts import is_valid
+
+SHA_ZERO = "0" * 64
+
+_FILE_ENTRY = {
+    "path": "sample.pdf",
+    "size_bytes": 100,
+    "sha256": SHA_ZERO,
+    "file_type": "pdf",
+}
+
+
+class TestRegistry:
+    """Adapter registry: register, get, available."""
+
+    def test_get_unknown_raises_key_error(self) -> None:
+        with pytest.raises(KeyError, match="Unknown adapter"):
+            get("__nonexistent__")
+
+    def test_register_and_get_roundtrip(self) -> None:
+        class _DummyAdapter(AdapterBase):
+            name = "__test_dummy__"
+            version = "0.0.0"
+
+            def extract(self, manifest_file, source_root):
+                return {}
+
+        inst = _DummyAdapter()
+        register(inst)
+        assert get("__test_dummy__") is inst
+
+    def test_available_returns_sorted_list(self) -> None:
+        names = available()
+        assert names == sorted(names)
+        assert isinstance(names, list)
+
+    def test_builtin_adapters_lazy_load(self) -> None:
+        for name in ("kreuzberg", "claude_cli", "docling", "glm_ocr", "paddle_ocr"):
+            adapter = get(name)
+            assert adapter.name == name
+
+
+class TestKreuzbergAdapter:
+    """KreuzbergAdapter delegates to the kreuzberg stage function."""
+
+    def test_extract_delegates_to_stage(self, tmp_path: Path) -> None:
+        from doc_pipeline_engine.stages._adapters.kreuzberg import KreuzbergAdapter
+
+        fake_bundle = {
+            "version": "0.1.0",
+            "source_path": "sample.pdf",
+            "source_sha256": SHA_ZERO,
+            "adapter": {"name": "kreuzberg", "version": "1.0"},
+            "extracted_at": "2026-01-01T00:00:00+00:00",
+            "content": {"text": "hello", "layout": []},
+        }
+        adapter = KreuzbergAdapter()
+        with patch("doc_pipeline_engine.stages._adapters.kreuzberg._kreuzberg_extract", return_value=fake_bundle):
+            result = adapter.extract(_FILE_ENTRY, tmp_path)
+
+        assert result == fake_bundle
+        assert is_valid("ExtractionBundle", result)
+
+
+class TestClaudeCliAdapter:
+    """ClaudeCliAdapter shells out to claude --print --bare."""
+
+    def _make_envelope(self, text: str) -> bytes:
+        return json.dumps({"result": text, "usage": {"input_tokens": 10, "output_tokens": 20}, "model": "claude-opus-4-8"}).encode()
+
+    def test_extract_happy_path(self, tmp_path: Path) -> None:
+        from doc_pipeline_engine.stages._adapters.claude_cli import ClaudeCliAdapter
+
+        pdf = tmp_path / "sample.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = self._make_envelope("Extracted text content.")
+        fake_result.stderr = b""
+
+        adapter = ClaudeCliAdapter()
+        with patch("subprocess.run", return_value=fake_result):
+            result = adapter.extract({"path": "sample.pdf", "sha256": SHA_ZERO}, tmp_path)
+
+        assert result["content"]["text"] == "Extracted text content."
+        assert result["adapter"]["name"] == "claude_cli"
+        assert is_valid("ExtractionBundle", result)
+
+    def test_extract_missing_cli_raises_runtime_error(self, tmp_path: Path) -> None:
+        from doc_pipeline_engine.stages._adapters.claude_cli import ClaudeCliAdapter
+
+        pdf = tmp_path / "sample.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        adapter = ClaudeCliAdapter()
+        with patch("subprocess.run", side_effect=FileNotFoundError("claude not found")):
+            with pytest.raises(RuntimeError, match="Claude Code CLI not found"):
+                adapter.extract({"path": "sample.pdf", "sha256": SHA_ZERO}, tmp_path)
+
+    def test_extract_nonzero_exit_raises_runtime_error(self, tmp_path: Path) -> None:
+        from doc_pipeline_engine.stages._adapters.claude_cli import ClaudeCliAdapter
+
+        pdf = tmp_path / "sample.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 1
+        fake_result.stdout = b""
+        fake_result.stderr = b"auth error"
+
+        adapter = ClaudeCliAdapter()
+        with patch("subprocess.run", return_value=fake_result):
+            with pytest.raises(RuntimeError, match="claude exited 1"):
+                adapter.extract({"path": "sample.pdf", "sha256": SHA_ZERO}, tmp_path)
+
+    def test_extract_invalid_json_falls_back_to_raw(self, tmp_path: Path) -> None:
+        from doc_pipeline_engine.stages._adapters.claude_cli import ClaudeCliAdapter
+
+        pdf = tmp_path / "sample.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        fake_result = MagicMock()
+        fake_result.returncode = 0
+        fake_result.stdout = b"plain text output"
+        fake_result.stderr = b""
+
+        adapter = ClaudeCliAdapter()
+        with patch("subprocess.run", return_value=fake_result):
+            result = adapter.extract({"path": "sample.pdf", "sha256": SHA_ZERO}, tmp_path)
+
+        assert result["content"]["text"] == "plain text output"
+
+
+class TestStubAdapters:
+    """Stub adapters raise NotImplementedError."""
+
+    @pytest.mark.parametrize("name", ["docling", "glm_ocr", "paddle_ocr"])
+    def test_stub_raises_not_implemented(self, name: str, tmp_path: Path) -> None:
+        adapter = get(name)
+        with pytest.raises(NotImplementedError):
+            adapter.extract(_FILE_ENTRY, tmp_path)

--- a/tests/test_domain_packs.py
+++ b/tests/test_domain_packs.py
@@ -1,0 +1,130 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for the domain pack registry and concrete packs (§0.5.0)."""
+from __future__ import annotations
+
+import pytest
+
+from doc_pipeline_engine.domain import DomainPack, available, get, register
+from doc_pipeline_engine.domain.formats import (
+    available_inputs,
+    available_outputs,
+    get_input,
+    get_output,
+)
+
+
+class TestDomainPackRegistry:
+    """Domain pack registry: get, register, available."""
+
+    def test_get_unknown_raises_key_error(self) -> None:
+        with pytest.raises(KeyError, match="Unknown domain pack"):
+            get("__nonexistent__")
+
+    def test_register_and_get_roundtrip(self) -> None:
+        pack = DomainPack(
+            name="__test__",
+            policy="local-only",
+            input_format_ids=[],
+            output_format_ids=[],
+        )
+        register(pack)
+        assert get("__test__") is pack
+
+    def test_available_returns_sorted_list(self) -> None:
+        names = available()
+        assert names == sorted(names)
+
+    def test_builtin_packs_lazy_load(self) -> None:
+        for name in ("generic", "mech-elec-cert", "med-research-patents"):
+            pack = get(name)
+            assert pack.name == name
+
+
+class TestGenericPack:
+    """generic pack is fully wired: formats, policy, prompts, threshold."""
+
+    def setup_method(self) -> None:
+        self.pack = get("generic")
+
+    def test_policy_is_claude_api_extracted_only(self) -> None:
+        assert self.pack.policy == "claude-api-extracted-only"
+
+    def test_has_four_input_formats(self) -> None:
+        assert len(self.pack.input_format_ids) == 4
+
+    def test_has_two_output_formats(self) -> None:
+        assert len(self.pack.output_format_ids) == 2
+
+    def test_input_format_ids_are_registered(self) -> None:
+        for fmt_id in self.pack.input_format_ids:
+            fmt = get_input(fmt_id)
+            assert fmt.id == fmt_id
+
+    def test_output_format_ids_are_registered(self) -> None:
+        for fmt_id in self.pack.output_format_ids:
+            fmt = get_output(fmt_id)
+            assert fmt.id == fmt_id
+
+    def test_threshold_is_0_7(self) -> None:
+        assert self.pack.extraction_confidence_threshold == 0.7
+
+    def test_prompts_cover_three_stages(self) -> None:
+        for stage in ("normalize", "analyze", "draft"):
+            assert stage in self.pack.prompts
+            assert self.pack.prompts[stage]
+
+
+class TestStubPacks:
+    """Stub packs declare their policy and have empty format lists."""
+
+    def test_mech_elec_cert_policy_local_only(self) -> None:
+        pack = get("mech-elec-cert")
+        assert pack.policy == "local-only"
+        assert pack.input_format_ids == []
+
+    def test_med_research_patents_policy_cloud_redacted(self) -> None:
+        pack = get("med-research-patents")
+        assert pack.policy == "cloud-redacted"
+        assert pack.input_format_ids == []
+
+    def test_mech_elec_cert_threshold_higher(self) -> None:
+        assert get("mech-elec-cert").extraction_confidence_threshold == 0.85
+
+    def test_med_research_patents_threshold_highest(self) -> None:
+        assert get("med-research-patents").extraction_confidence_threshold == 0.9
+
+
+class TestFormatRegistry:
+    """Format registry get/available functions."""
+
+    def test_get_input_unknown_raises_key_error(self) -> None:
+        with pytest.raises(KeyError, match="Unknown input format"):
+            get_input("__nonexistent__/__format__")
+
+    def test_get_output_unknown_raises_key_error(self) -> None:
+        with pytest.raises(KeyError, match="Unknown output format"):
+            get_output("__nonexistent__/__format__")
+
+    def test_available_inputs_sorted(self) -> None:
+        names = available_inputs()
+        assert names == sorted(names)
+
+    def test_available_outputs_sorted(self) -> None:
+        names = available_outputs()
+        assert names == sorted(names)
+
+    def test_generic_inputs_present_after_pack_load(self) -> None:
+        get("generic")  # ensure pack loaded
+        for fmt_id in ("generic/text", "generic/pdf", "generic/office", "generic/image"):
+            assert get_input(fmt_id).id == fmt_id
+
+    def test_generic_outputs_present_after_pack_load(self) -> None:
+        get("generic")
+        for fmt_id in ("generic/quick-summary", "generic/comprehensive-report"):
+            assert get_output(fmt_id).id == fmt_id

--- a/tests/test_failure_gates.py
+++ b/tests/test_failure_gates.py
@@ -139,10 +139,17 @@ class TestF5PolicyViolation:
         gate = PolicyGate("generic")
         gate.check("claude_cli")  # must not raise
 
-    def test_unknown_adapter_rejected_by_any_policy(self) -> None:
-        gate = PolicyGate("generic")
+    def test_unknown_adapter_rejected_by_local_only_policy(self) -> None:
+        # Unknown adapters have no locality attribute; treated as non-local
+        # and therefore blocked under local-only policy.
+        gate = PolicyGate("mech-elec-cert")
         with pytest.raises(GateError, match="F5-policy-violation"):
             gate.check("__unknown_adapter__")
+
+    def test_unknown_adapter_allowed_by_permissive_policy(self) -> None:
+        # Non-local-only policies permit any adapter (including unknown ones).
+        gate = PolicyGate("generic")
+        gate.check("__unknown_adapter__")  # must not raise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_failure_gates.py
+++ b/tests/test_failure_gates.py
@@ -1,0 +1,225 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Failure-mode gate tests (§0.6.0).
+
+Covers:
+  F1  — corrupt/unreadable input → adapter raises, does not emit a bundle
+  F4  — schema drift → contract gate rejects malformed stage output
+  F5  — policy violation → PolicyGate rejects disallowed adapter
+  F11 — format miss → FormatGate rejects file type not in pack
+  F12 — required-section miss → contract gate rejects bundle missing field
+
+F2 (adapter disagreement) is deferred: requires two real adapters running
+against the same file (integration test, not unit test).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from doc_pipeline_engine.base.contracts import is_valid
+from doc_pipeline_engine.base.gates import ConfidenceGate, FormatGate, GateError, PolicyGate
+from doc_pipeline_engine.runner import PipelineError, run
+
+SHA_ZERO = "0" * 64
+NOW = datetime.now(timezone.utc).isoformat()
+
+_VALID_BUNDLE = {
+    "version": "0.1.0",
+    "source_path": "a.pdf",
+    "source_sha256": SHA_ZERO,
+    "adapter": {"name": "stub", "version": "0.0.0"},
+    "extracted_at": NOW,
+    "content": {"text": "hello", "layout": []},
+}
+
+
+# ---------------------------------------------------------------------------
+# F1 — Corrupt input: adapter raises, pipeline halts
+# ---------------------------------------------------------------------------
+
+
+class TestF1CorruptInput:
+    """F1: corrupt or unreadable input propagates as a pipeline halt."""
+
+    def test_kreuzberg_adapter_raises_on_corrupt_file(self, tmp_path: Path) -> None:
+        corrupt = tmp_path / "corrupt.pdf"
+        corrupt.write_bytes(b"NOT A PDF")
+
+        from doc_pipeline_engine.stages._adapters.kreuzberg import KreuzbergAdapter
+
+        adapter = KreuzbergAdapter()
+        with patch(
+            "doc_pipeline_engine.stages._adapters.kreuzberg._kreuzberg_extract",
+            side_effect=RuntimeError("Kreuzberg: cannot parse file"),
+        ):
+            with pytest.raises(RuntimeError, match="Kreuzberg: cannot parse file"):
+                adapter.extract(
+                    {"path": "corrupt.pdf", "sha256": SHA_ZERO}, tmp_path
+                )
+
+    def test_runner_halts_when_extract_stage_raises(self) -> None:
+        def _bad_extract(_manifest: dict) -> dict:
+            raise RuntimeError("corrupt input")
+
+        stages = [
+            ("extract", _bad_extract, "ExtractionBundle"),
+        ]
+        with pytest.raises(RuntimeError, match="corrupt input"):
+            run(stages, seed={})
+
+
+# ---------------------------------------------------------------------------
+# F4 — Schema drift: stage emits wrong type for a required field
+# ---------------------------------------------------------------------------
+
+
+class TestF4SchemaDrift:
+    """F4: stage output with wrong field type is rejected by the contract gate."""
+
+    def test_discovery_manifest_rejects_non_string_path(self) -> None:
+        drifted = {
+            "version": "0.1.0",
+            "source": {"root": "/data", "kind": "folder"},
+            "discovered_at": NOW,
+            "files": [
+                {
+                    "path": 12345,  # int, not str — schema drift
+                    "size_bytes": 100,
+                    "sha256": SHA_ZERO,
+                    "file_type": "pdf",
+                }
+            ],
+        }
+        assert not is_valid("DiscoveryManifest", drifted)
+
+    def test_runner_halts_on_drifted_discovery_manifest(self) -> None:
+        def _drifted_discover(_seed: dict) -> dict:
+            return {
+                "version": "0.1.0",
+                "source": {"root": "/data", "kind": "folder"},
+                "discovered_at": NOW,
+                "files": [{"path": 99, "size_bytes": 100, "sha256": SHA_ZERO, "file_type": "pdf"}],
+            }
+
+        with pytest.raises(PipelineError) as exc:
+            run([("discover", _drifted_discover, "DiscoveryManifest")], seed={})
+        assert exc.value.contract_name == "DiscoveryManifest"
+
+
+# ---------------------------------------------------------------------------
+# F5 — Policy violation: cloud adapter + local-only pack
+# ---------------------------------------------------------------------------
+
+
+class TestF5PolicyViolation:
+    """F5: PolicyGate rejects adapters disallowed by the pack's data-locality policy."""
+
+    def test_claude_cli_rejected_by_local_only_pack(self) -> None:
+        gate = PolicyGate("mech-elec-cert")
+        with pytest.raises(GateError) as exc:
+            gate.check("claude_cli")
+        assert exc.value.gate == "F5-policy-violation"
+        assert "claude_cli" in exc.value.detail
+        assert "local-only" in exc.value.detail
+
+    def test_kreuzberg_allowed_by_local_only_pack(self) -> None:
+        gate = PolicyGate("mech-elec-cert")
+        gate.check("kreuzberg")  # must not raise
+
+    def test_claude_cli_allowed_by_claude_api_extracted_only_pack(self) -> None:
+        gate = PolicyGate("generic")
+        gate.check("claude_cli")  # must not raise
+
+    def test_unknown_adapter_rejected_by_any_policy(self) -> None:
+        gate = PolicyGate("generic")
+        with pytest.raises(GateError, match="F5-policy-violation"):
+            gate.check("__unknown_adapter__")
+
+
+# ---------------------------------------------------------------------------
+# F11 — Format miss: file type not in pack's accepted input formats
+# ---------------------------------------------------------------------------
+
+
+class TestF11FormatMiss:
+    """F11: FormatGate rejects files whose type is not in the pack's input formats."""
+
+    def test_svg_rejected_by_generic_pack(self) -> None:
+        gate = FormatGate("generic")
+        with pytest.raises(GateError) as exc:
+            gate.check({"path": "diagram.svg", "sha256": SHA_ZERO, "file_type": "svg"})
+        assert exc.value.gate == "F11-format-miss"
+        assert "svg" in exc.value.detail
+
+    def test_pdf_accepted_by_generic_pack(self) -> None:
+        gate = FormatGate("generic")
+        gate.check({"path": "doc.pdf", "sha256": SHA_ZERO, "file_type": "pdf"})
+
+    def test_txt_accepted_by_generic_pack(self) -> None:
+        gate = FormatGate("generic")
+        gate.check({"path": "notes.txt", "sha256": SHA_ZERO, "file_type": "txt"})
+
+    def test_unknown_type_rejected_by_generic_pack(self) -> None:
+        gate = FormatGate("generic")
+        with pytest.raises(GateError, match="F11-format-miss"):
+            gate.check({"path": "data.xyz", "sha256": SHA_ZERO, "file_type": "xyz"})
+
+
+# ---------------------------------------------------------------------------
+# F12 — Required-section miss: ExtractionBundle missing required field
+# ---------------------------------------------------------------------------
+
+
+class TestF12RequiredSectionMiss:
+    """F12: contract gate rejects ExtractionBundle missing a required field."""
+
+    def test_bundle_missing_content_fails_validation(self) -> None:
+        bundle = dict(_VALID_BUNDLE)
+        del bundle["content"]
+        assert not is_valid("ExtractionBundle", bundle)
+
+    def test_bundle_missing_source_path_fails_validation(self) -> None:
+        bundle = dict(_VALID_BUNDLE)
+        del bundle["source_path"]
+        assert not is_valid("ExtractionBundle", bundle)
+
+    def test_runner_halts_on_bundle_missing_required_field(self) -> None:
+        def _bad_bundle(_seed: dict) -> dict:
+            b = dict(_VALID_BUNDLE)
+            del b["content"]
+            return b
+
+        with pytest.raises(PipelineError) as exc:
+            run([("extract", _bad_bundle, "ExtractionBundle")], seed={})
+        assert exc.value.contract_name == "ExtractionBundle"
+
+
+# ---------------------------------------------------------------------------
+# ConfidenceGate (F2 partial)
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceGate:
+    """ConfidenceGate rejects bundles below the pack threshold."""
+
+    def test_low_confidence_rejected(self) -> None:
+        gate = ConfidenceGate("generic")  # threshold 0.7
+        with pytest.raises(GateError, match="G-extract-confidence"):
+            gate.check({**_VALID_BUNDLE, "confidence": 0.5})
+
+    def test_high_confidence_accepted(self) -> None:
+        gate = ConfidenceGate("generic")
+        gate.check({**_VALID_BUNDLE, "confidence": 0.9})  # must not raise
+
+    def test_missing_confidence_accepted(self) -> None:
+        gate = ConfidenceGate("generic")
+        gate.check(_VALID_BUNDLE)  # confidence absent — must not raise

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,153 @@
+# Copyright 2026 qte77
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for the NDJSON stream interface (§0.3.0)."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from doc_pipeline_engine.stream import main, run_stream
+
+SHA_ZERO = "0" * 64
+NOW = datetime.now(timezone.utc).isoformat()
+
+_MIN_DISCOVERY = {
+    "version": "0.1.0",
+    "source": {"root": "/data/ingest", "kind": "folder"},
+    "discovered_at": NOW,
+    "files": [
+        {
+            "path": "a.pdf",
+            "size_bytes": 100,
+            "sha256": SHA_ZERO,
+            "file_type": "pdf",
+        }
+    ],
+}
+
+
+def _capture_stream(stage_names: list[str], seed: dict) -> tuple[int, list[dict]]:
+    """Run run_stream and collect emitted NDJSON lines."""
+    lines: list[dict] = []
+    original_write = __import__("sys").stdout.write
+
+    captured: list[str] = []
+
+    def mock_write(s: str) -> None:
+        captured.append(s)
+
+    import sys
+
+    with patch.object(sys.stdout, "write", side_effect=mock_write):
+        with patch.object(sys.stdout, "flush"):
+            code = run_stream(stage_names, seed)
+
+    for chunk in captured:
+        for line in chunk.splitlines():
+            line = line.strip()
+            if line:
+                lines.append(json.loads(line))
+
+    return code, lines
+
+
+class TestRunStream:
+    """run_stream emits correct NDJSON for the discover stage."""
+
+    def test_discover_happy_path(self, tmp_path: Path) -> None:
+        pdf = tmp_path / "sample.pdf"
+        pdf.write_bytes(b"%PDF-1.4 minimal")
+
+        seed = {"root": str(tmp_path), "glob": "**/*"}
+        code, lines = _capture_stream(["discover"], seed)
+
+        assert code == 0
+        assert len(lines) == 1
+        line = lines[0]
+        assert line["stage"] == "discover"
+        assert line["contract"] == "DiscoveryManifest"
+        assert "output" in line
+        assert len(line["output"]["files"]) == 1
+        assert line["output"]["files"][0]["path"] == "sample.pdf"
+
+    def test_unknown_stage_returns_error_line(self) -> None:
+        code, lines = _capture_stream(["nonexistent"], {})
+
+        assert code == 1
+        assert len(lines) == 1
+        assert "error" in lines[0]
+        assert "nonexistent" in lines[0]["error"]
+
+    def test_contract_failure_emits_error_line(self, tmp_path: Path) -> None:
+        # Patch discover to return an invalid contract dict (missing required fields)
+        from doc_pipeline_engine import stream as stream_mod
+
+        bad_output = {"not": "a valid DiscoveryManifest"}
+
+        def bad_discover(seed: dict) -> dict:
+            return bad_output
+
+        with patch.object(stream_mod, "_STAGE_REGISTRY", {}):
+            with patch("doc_pipeline_engine.stages.discover.discover", return_value=bad_output):
+                code, lines = _capture_stream(["discover"], {"root": str(tmp_path)})
+
+        assert code == 1
+        assert lines[-1].get("error") or lines[-1].get("stage") == "discover"
+
+    def test_empty_stage_list_returns_zero(self) -> None:
+        code, lines = _capture_stream([], {})
+        assert code == 0
+        assert lines == []
+
+
+class TestMain:
+    """main() reads seed from stdin and drives run_stream."""
+
+    def test_no_args_returns_2(self) -> None:
+        code = main([])
+        assert code == 2
+
+    def test_invalid_json_stdin_returns_2(self, tmp_path: Path) -> None:
+        import sys
+
+        with patch.object(sys.stdin, "read", return_value="not json"):
+            code = main(["discover"])
+        assert code == 2
+
+    def test_discover_via_main(self, tmp_path: Path) -> None:
+        import sys
+
+        pdf = tmp_path / "doc.pdf"
+        pdf.write_bytes(b"%PDF-1.4 minimal")
+        seed_json = json.dumps({"root": str(tmp_path), "glob": "**/*"})
+
+        lines: list[dict] = []
+        captured: list[str] = []
+
+        def mock_write(s: str) -> None:
+            captured.append(s)
+
+        with patch.object(sys.stdin, "read", return_value=seed_json):
+            with patch.object(sys.stdout, "write", side_effect=mock_write):
+                with patch.object(sys.stdout, "flush"):
+                    code = main(["discover"])
+
+        for chunk in captured:
+            for line in chunk.splitlines():
+                line = line.strip()
+                if line:
+                    lines.append(json.loads(line))
+
+        assert code == 0
+        assert lines[0]["stage"] == "discover"
+        assert lines[0]["output"]["files"][0]["path"] == "doc.pdf"


### PR DESCRIPTION
## Summary

Four milestones shipped in a single branch, each building on the last:

**§0.3.0 — Stream**: `doc_pipeline_engine.stream` reads seed JSON from stdin,
emits one NDJSON line per stage to stdout; exits 1 with an error line on
contract failure. `doc-pipeline` CLI entry point wired via `[project.scripts]`.

**§0.4.0 — Adapters**: Adapter registry (register / get / available) with lazy
built-in loading. Concrete adapters: KreuzbergAdapter (delegates to existing
stage), ClaudeCliAdapter (shells out to `claude --print --bare`, locality="api"),
three stubs (Docling, GLM-OCR, PaddleOCR-VL) raising NotImplementedError.

**§0.5.0 — Domain packs**: DomainPack dataclass + pack registry + format registry.
Built-in packs: generic (fully wired — 4 input formats, 2 output formats,
prompts for normalize/analyze/draft, threshold 0.7), mech-elec-cert and
med-research-patents as declared stubs with policy and threshold set.

**§0.6.0 — Gates + failure tests**: FormatGate (F11), PolicyGate (F5),
ConfidenceGate. PolicyGate derives from adapter `locality` attribute — no
hardcoded allowlist. Failure tests: F1 (corrupt input), F4 (schema drift),
F5 (policy violation), F11 (format miss), F12 (required-section miss).
F2 (adapter disagreement) and RAGAs/TruLens/DeepEval harness wrappers deferred.

## Test plan

- [ ] `make test` — 143 pass, 6 pre-existing skips (missing docx extra)
- [ ] `make lint` — ruff clean on all new modules
- [ ] `make test_stream` — 7 stream tests
- [ ] `make test_adapters` — 12 adapter tests
- [ ] Smoke: `echo '{"root": "."}' | uv run doc-pipeline discover`

Generated with Claude <noreply@anthropic.com>