### PR TITLE
fix(setup_lychee): extract from tmpdir, install to ~/.local/bin, no sudo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,16 @@ setup_npm_tools:  ## Install npm-based dev tools (markdownlint-cli2)
 	npm install -gs markdownlint-cli2
 	echo "markdownlint-cli2 version: $$(markdownlint-cli2 --version)"
 
-setup_lychee:  ## Install lychee link checker (Rust binary, requires sudo)
+setup_lychee:  ## Install lychee link checker (~/.local/bin, no sudo)
 	if command -v lychee > /dev/null 2>&1; then
 		echo "lychee already installed: $$(lychee --version)"
 	else
-		curl -sL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
-			| sudo tar xz -C /usr/local/bin lychee
+		mkdir -p ~/.local/bin
+		tmp=$$(mktemp -d) \
+			&& curl -sSfL https://github.com/lycheeverse/lychee/releases/latest/download/lychee-x86_64-unknown-linux-gnu.tar.gz \
+				| tar xz -C "$$tmp" \
+			&& install -m 755 "$$tmp"/lychee-*/lychee ~/.local/bin/lychee \
+			&& rm -rf "$$tmp"
 		echo "lychee installed: $$(lychee --version)"
 	fi
 


### PR DESCRIPTION
## Summary

- Fixes #96: `tar xz -C /usr/local/bin lychee` silently skips the binary because lychee release tarballs wrap it inside `lychee-<target>/lychee`, not at the tarball root
- Extracts to a `mktemp -d` tmpdir, then uses `install -m 755 tmp/lychee-*/lychee` to glob the wrapper dir and install atomically
- Drops `sudo` in favour of `~/.local/bin` (qte77 convention; no root needed in devcontainer)
- Mirrors the canonical install pattern from `lycheeverse/lychee-action`

## Test plan

- [ ] Fresh runner (no cached lychee): `make setup_lychee` creates `~/.local/bin/lychee` and prints version
- [ ] Idempotent: re-running `make setup_lychee` prints "already installed" and skips download
- [ ] CI (lint/links, markdown, CodeFactor, CodeQL) green

Generated with Claude <noreply@anthropic.com>