### PR TITLE
chore: add TCH ruff rule — type-checking imports (issue #75 sub-PR C)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ target-version = "py311"
 # Narrow set: only require module / class / function / package docstrings.
 # Google convention; private (_-prefixed) names skipped automatically.
 # S = bandit-equivalent security checks. C90 = McCabe complexity (≤ 10).
-select = ["D100", "D101", "D103", "D104", "S", "C90", "E", "F", "I", "W", "UP", "PGH", "B", "SIM", "RUF", "N", "PT"]
+select = ["D100", "D101", "D103", "D104", "S", "C90", "E", "F", "I", "W", "UP", "PGH", "B", "SIM", "RUF", "N", "PT", "TCH"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/scripts/gen_contracts_md.py
+++ b/scripts/gen_contracts_md.py
@@ -26,10 +26,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-
-from pydantic import BaseModel
+from typing import TYPE_CHECKING
 
 from doc_pipeline_engine.models import REGISTRY
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 OUTPUT_PATH = REPO_ROOT / "docs" / "contracts.md"

--- a/src/doc_pipeline_engine/base/adapter.py
+++ b/src/doc_pipeline_engine/base/adapter.py
@@ -22,8 +22,10 @@ Built-in adapters (lazy-imported on first use):
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 Locality = str
 """Data locality of an adapter: ``"local"`` (on-device) or ``"api"`` (external LLM call)."""

--- a/src/doc_pipeline_engine/domain/formats.py
+++ b/src/doc_pipeline_engine/domain/formats.py
@@ -12,8 +12,11 @@ The registry is populated when domain pack modules are imported.
 """
 from __future__ import annotations
 
-from doc_pipeline_engine.models.input_format import InputFormat
-from doc_pipeline_engine.models.output_format import OutputFormat
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from doc_pipeline_engine.models.input_format import InputFormat
+    from doc_pipeline_engine.models.output_format import OutputFormat
 
 _INPUT: dict[str, InputFormat] = {}
 _OUTPUT: dict[str, OutputFormat] = {}

--- a/src/doc_pipeline_engine/harness.py
+++ b/src/doc_pipeline_engine/harness.py
@@ -25,9 +25,10 @@ import sys
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from doc_pipeline_engine.render.formats import RenderArtifacts
+if TYPE_CHECKING:
+    from doc_pipeline_engine.render.formats import RenderArtifacts
 
 
 @dataclass

--- a/src/doc_pipeline_engine/models/__init__.py
+++ b/src/doc_pipeline_engine/models/__init__.py
@@ -13,7 +13,7 @@ the contract's short name to its model class so the gate validator and the
 """
 from __future__ import annotations
 
-from pydantic import BaseModel
+from typing import TYPE_CHECKING
 
 from .analysis_report import AnalysisReport
 from .canonical_doc import CanonicalDoc
@@ -25,6 +25,9 @@ from .format_conformance import FormatConformance
 from .format_match import FormatMatch
 from .input_format import InputFormat
 from .output_format import OutputFormat
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
 REGISTRY: dict[str, type[BaseModel]] = {
     "AnalysisReport": AnalysisReport,

--- a/src/doc_pipeline_engine/stages/_adapters/claude_cli.py
+++ b/src/doc_pipeline_engine/stages/_adapters/claude_cli.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import json
 import subprocess
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 ADAPTER_NAME = "claude_cli"
 ADAPTER_VERSION = "0.1.0"

--- a/src/doc_pipeline_engine/stages/_adapters/docling.py
+++ b/src/doc_pipeline_engine/stages/_adapters/docling.py
@@ -8,10 +8,12 @@
 """Docling adapter stub — not yet implemented."""
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class DoclingAdapter(AdapterBase):

--- a/src/doc_pipeline_engine/stages/_adapters/glm_ocr.py
+++ b/src/doc_pipeline_engine/stages/_adapters/glm_ocr.py
@@ -8,10 +8,12 @@
 """GLM-OCR adapter stub — not yet implemented."""
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class GlmOcrAdapter(AdapterBase):

--- a/src/doc_pipeline_engine/stages/_adapters/kreuzberg.py
+++ b/src/doc_pipeline_engine/stages/_adapters/kreuzberg.py
@@ -8,11 +8,13 @@
 """Kreuzberg adapter — wraps the existing Kreuzberg-backed extract stage."""
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from doc_pipeline_engine.base.adapter import AdapterBase, register
 from doc_pipeline_engine.stages.extract import extract as _kreuzberg_extract
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class KreuzbergAdapter(AdapterBase):

--- a/src/doc_pipeline_engine/stages/_adapters/paddle_ocr.py
+++ b/src/doc_pipeline_engine/stages/_adapters/paddle_ocr.py
@@ -8,10 +8,12 @@
 """PaddleOCR-VL adapter stub — not yet implemented."""
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from doc_pipeline_engine.base.adapter import AdapterBase, register
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class PaddleOcrAdapter(AdapterBase):

--- a/src/doc_pipeline_engine/stages/anthropic_sdk_eval.py
+++ b/src/doc_pipeline_engine/stages/anthropic_sdk_eval.py
@@ -14,9 +14,10 @@ PR 6 (the harness) to add when comparative scoring across legs is wired.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from doc_pipeline_engine.render.formats import RenderArtifacts
+if TYPE_CHECKING:
+    from doc_pipeline_engine.render.formats import RenderArtifacts
 
 CONTRACT_VERSION = "0.1.0"
 

--- a/src/doc_pipeline_engine/stages/discover.py
+++ b/src/doc_pipeline_engine/stages/discover.py
@@ -14,8 +14,10 @@ from __future__ import annotations
 
 import hashlib
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 CONTRACT_VERSION = "0.1.0"
 _HASH_CHUNK = 65536

--- a/src/doc_pipeline_engine/stages/extract.py
+++ b/src/doc_pipeline_engine/stages/extract.py
@@ -21,10 +21,12 @@ SVG is not supported.
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Callable
 from datetime import UTC, datetime
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
 
 ADAPTER_NAME = "kreuzberg"
 CONTRACT_VERSION = "0.1.0"

--- a/src/doc_pipeline_engine/stages/local_eval.py
+++ b/src/doc_pipeline_engine/stages/local_eval.py
@@ -14,9 +14,10 @@ is needed.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from doc_pipeline_engine.render.formats import RenderArtifacts
+if TYPE_CHECKING:
+    from doc_pipeline_engine.render.formats import RenderArtifacts
 
 CONTRACT_VERSION = "0.1.0"
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -9,13 +9,16 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from doc_pipeline_engine.base.adapter import AdapterBase, available, get, register
 from doc_pipeline_engine.base.contracts import is_valid
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 SHA_ZERO = "0" * 64
 

--- a/tests/test_external_anthropic_sdk_run_oneshot.py
+++ b/tests/test_external_anthropic_sdk_run_oneshot.py
@@ -17,8 +17,10 @@ import importlib.util
 import json
 from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 
-import pytest
+if TYPE_CHECKING:
+    import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 _spec = importlib.util.spec_from_file_location(

--- a/tests/test_failure_gates.py
+++ b/tests/test_failure_gates.py
@@ -20,7 +20,7 @@ against the same file (integration test, not unit test).
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
@@ -28,6 +28,9 @@ import pytest
 from doc_pipeline_engine.base.contracts import is_valid
 from doc_pipeline_engine.base.gates import ConfidenceGate, FormatGate, GateError, PolicyGate
 from doc_pipeline_engine.runner import PipelineError, run
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 SHA_ZERO = "0" * 64
 NOW = datetime.now(UTC).isoformat()

--- a/tests/test_harness_diff_both_variants.py
+++ b/tests/test_harness_diff_both_variants.py
@@ -13,8 +13,7 @@ artifact write-out, axes computation, JSON serialisation.
 """
 from __future__ import annotations
 
-from pathlib import Path
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
@@ -30,6 +29,9 @@ from doc_pipeline_engine.harness import (
 )
 from doc_pipeline_engine.render.formats import RenderArtifacts
 from doc_pipeline_engine.stages import extract as extract_module
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 SHA = "0" * 64
 

--- a/tests/test_stages_discover_behavior.py
+++ b/tests/test_stages_discover_behavior.py
@@ -11,10 +11,13 @@ a valid DiscoveryManifest dict.
 from __future__ import annotations
 
 import hashlib
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from doc_pipeline_engine.base.contracts import is_valid
 from doc_pipeline_engine.stages.discover import discover
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _write(p: Path, content: bytes) -> None:

--- a/tests/test_stages_extract_kreuzberg_properties.py
+++ b/tests/test_stages_extract_kreuzberg_properties.py
@@ -16,14 +16,16 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from doc_pipeline_engine.base.contracts import is_valid
 from doc_pipeline_engine.stages import extract as extract_module
 from doc_pipeline_engine.stages.extract import extract
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @dataclass

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -10,10 +10,13 @@ from __future__ import annotations
 
 import json
 from datetime import UTC, datetime
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 from doc_pipeline_engine.stream import main, run_stream
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 SHA_ZERO = "0" * 64
 NOW = datetime.now(UTC).isoformat()


### PR DESCRIPTION
## Summary

- Extends `[tool.ruff.lint] select` with `TCH` (flake8-type-checking)
- 23 imports moved into `if TYPE_CHECKING:` blocks via `--unsafe-fixes` (needed as ruff won't auto-apply without the flag)
- Import sort re-applied after restructuring
- No Pydantic breakage: all files have `from __future__ import annotations` so annotation evaluation is deferred

## Key changes

- `TCH003 (stdlib)`: `Path`, `Callable` moved to TYPE_CHECKING in 14 files (stages, tests)
- `TCH002 (third-party)`: `pydantic.BaseModel`, `pytest` moved to TYPE_CHECKING
- `TCH001 (application)`: `RenderArtifacts`, `InputFormat`, `OutputFormat` moved to TYPE_CHECKING in harness and domain formats

## Test plan

- [x] `python -m pytest` — 143 passed, 6 skipped (pre-existing docx skip)
- [x] `python -m ruff check .` — no violations

Closes #75 (sub-PR C — TCH type-checking imports)

Generated with Claude <noreply@anthropic.com>