### PR TITLE
chore(ruff): enable TRY rules with TRY003 silenced (issue #91-A)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,11 @@ target-version = "py311"
 # Narrow set: only require module / class / function / package docstrings.
 # Google convention; private (_-prefixed) names skipped automatically.
 # S = bandit-equivalent security checks. C90 = McCabe complexity (≤ 10).
-select = ["D100", "D101", "D103", "D104", "S", "C90", "E", "F", "I", "W", "UP", "PGH", "B", "SIM", "RUF", "N", "PT", "TCH"]
+select = ["D100", "D101", "D103", "D104", "S", "C90", "E", "F", "I", "W", "UP", "PGH", "B", "SIM", "RUF", "N", "PT", "TCH", "TRY"]
+
+ignore = [
+    "TRY003",  # long messages in defensive raises are clearer inline than in exception subclasses
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
## Summary

- Adds `TRY` (tryceratops — try/except hygiene) to `[tool.ruff.lint] select`
- Adds `"TRY003"` to `ignore` — all 18 violations are long defensive raises that read better inline than as dedicated exception classes
- No code changes; pyproject.toml only

## Test plan

- [x] `python -m ruff check .` — no violations
- [x] `python -m pytest` — 143 passed, 6 skipped

Closes #91-A

Generated with Claude <noreply@anthropic.com>