### PR TITLE
fix: render stages accept typed AnalysisReport (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `stages/local_render.py` + `stages/anthropic_sdk_render.py`: accept the typed `AnalysisReport` (attribute access; `model_dump(mode="json")` for the anthropic prompt) instead of dict-subscripting it. The #127 typed-return refactor left these two render stages un-migrated, so the harness legs crashed with `TypeError: 'AnalysisReport' object is not subscriptable`; the render unit tests masked it by passing dicts (now build real models). (#130)
 - `docs/landscape/ingest.md` marker row — corrected the stale "depends on surya (GPL-3.0)" claim: surya's LICENSE is Apache-2.0 (weights are RAIL-M, free < $5M rev) and marker's GPL-3.0 is its own code. Verified by direct LICENSE-file inspection. (#112)
 - `docs/roadmap.md` § 0.2.2: status `in progress` → `done` — all Delivered items shipped, ADR-0002 Accepted.
 - `docs/roadmap.md` § 0.2.2: stale claim "embedded in `docs/architecture.md` and `README.md`" replaced — SVG now only in `docs/architecture.md` (inside `<details>`) at the new `docs/assets/images/` path.

--- a/src/doc_pipeline_engine/stages/anthropic_sdk_render.py
+++ b/src/doc_pipeline_engine/stages/anthropic_sdk_render.py
@@ -14,7 +14,7 @@ is purely about the Markdown content quality.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import TYPE_CHECKING
 
 from doc_pipeline_engine.render.formats import RenderArtifacts, render_artifacts
 from doc_pipeline_engine.stages._anthropic_sdk_client import (
@@ -22,6 +22,9 @@ from doc_pipeline_engine.stages._anthropic_sdk_client import (
     _ClaudeClient,
     call_text,
 )
+
+if TYPE_CHECKING:
+    from doc_pipeline_engine.models.analysis_report import AnalysisReport
 
 _SYSTEM = """You are a document summarizer. Given an AnalysisReport
 (claims + entities), write a 1-page Markdown summary suitable for the
@@ -36,16 +39,17 @@ Output MARKDOWN ONLY (no prose, no JSON, no fences). Use:
 
 
 def render_anthropic_sdk(
-    report: dict[str, Any],
+    report: AnalysisReport,
     model: str = MODEL_DEFAULT,
     client: _ClaudeClient | None = None,
     title: str = "Quick Summary",
 ) -> RenderArtifacts:
     """AnalysisReport → RenderArtifacts (md + docx + pdf)."""
+    data = report.model_dump(mode="json")
     user = (
-        f"AnalysisReport source_sha256: {report['source_sha256']}\n\n"
-        f"Claims:\n{json.dumps(report['claims'])}\n\n"
-        f"Entities:\n{json.dumps(report['entities'])}"
+        f"AnalysisReport source_sha256: {data['source_sha256']}\n\n"
+        f"Claims:\n{json.dumps(data['claims'])}\n\n"
+        f"Entities:\n{json.dumps(data['entities'])}"
     )
     md = call_text(client, model=model, system=_SYSTEM, user=user)
     return render_artifacts(md, title=title)

--- a/src/doc_pipeline_engine/stages/local_render.py
+++ b/src/doc_pipeline_engine/stages/local_render.py
@@ -9,9 +9,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from doc_pipeline_engine.render.formats import RenderArtifacts, render_artifacts
+
+if TYPE_CHECKING:
+    from doc_pipeline_engine.models.analysis_report import AnalysisReport
 
 _TEMPLATE_DIR = Path(__file__).parent / "_jinja_templates"
 _TEMPLATE_NAME = "quick_summary.md.j2"
@@ -38,9 +41,9 @@ def _load_env() -> Any:
     )
 
 
-def render_local(report: dict[str, Any], title: str = "Quick Summary") -> RenderArtifacts:
+def render_local(report: AnalysisReport, title: str = "Quick Summary") -> RenderArtifacts:
     """AnalysisReport → RenderArtifacts (md + docx + pdf)."""
     env = _load_env()
     template = env.get_template(_TEMPLATE_NAME)
-    md = template.render(claims=report["claims"], entities=report.get("entities", []))
+    md = template.render(claims=report.claims, entities=report.entities)
     return render_artifacts(md, title=title)

--- a/tests/test_stages_anthropic_sdk_render_properties.py
+++ b/tests/test_stages_anthropic_sdk_render_properties.py
@@ -20,6 +20,7 @@ pytest.importorskip("docx")
 pytest.importorskip("markdown")
 pytest.importorskip("weasyprint")
 
+from doc_pipeline_engine.models.analysis_report import AnalysisReport, Claim
 from doc_pipeline_engine.render.formats import RenderArtifacts
 from doc_pipeline_engine.stages.anthropic_sdk_render import render_anthropic_sdk
 
@@ -34,14 +35,13 @@ def _stub_client(response_text: str) -> object:
     return SimpleNamespace(messages=SimpleNamespace(create=_create))
 
 
-def _report() -> dict:
-    return {
-        "version": "0.1.0",
-        "source_sha256": SHA,
-        "analyzed_at": "2026-04-26T00:00:00+00:00",
-        "claims": [{"id": "c1", "text": "x", "node_refs": ["s.1"]}],
-        "entities": [],
-    }
+def _report() -> AnalysisReport:
+    return AnalysisReport(
+        source_sha256=SHA,
+        analyzed_at="2026-04-26T00:00:00+00:00",
+        claims=[Claim(id="c1", text="x", node_refs=["s.1"])],
+        entities=[],
+    )
 
 
 def test_stages_v1_render_returns_render_artifacts() -> None:

--- a/tests/test_stages_local_render_snapshot.py
+++ b/tests/test_stages_local_render_snapshot.py
@@ -15,20 +15,22 @@ pytest.importorskip("docx")
 pytest.importorskip("markdown")
 pytest.importorskip("weasyprint")
 
+from doc_pipeline_engine.models.analysis_report import AnalysisReport, Claim, Entity
 from doc_pipeline_engine.render.formats import RenderArtifacts
 from doc_pipeline_engine.stages.local_render import render_local
 
 SHA = "0" * 64
 
 
-def _report(claims: list[dict] | None = None, entities: list[dict] | None = None) -> dict:
-    return {
-        "version": "0.1.0",
-        "source_sha256": SHA,
-        "analyzed_at": "2026-04-26T00:00:00+00:00",
-        "claims": claims or [{"id": "c1", "text": "x is y", "node_refs": ["s.1"]}],
-        "entities": entities or [],
-    }
+def _report(
+    claims: list[Claim] | None = None, entities: list[Entity] | None = None
+) -> AnalysisReport:
+    return AnalysisReport(
+        source_sha256=SHA,
+        analyzed_at="2026-04-26T00:00:00+00:00",
+        claims=claims or [Claim(id="c1", text="x is y", node_refs=["s.1"])],
+        entities=entities or [],
+    )
 
 
 def test_stages_v2_render_returns_render_artifacts() -> None:
@@ -40,7 +42,7 @@ def test_stages_v2_render_returns_render_artifacts() -> None:
 
 
 def test_stages_v2_render_md_contains_claim_text() -> None:
-    claim = {"id": "c1", "text": "Sky is blue.", "node_refs": ["s.1"]}
+    claim = Claim(id="c1", text="Sky is blue.", node_refs=["s.1"])
 
     art = render_local(_report(claims=[claim]))
 
@@ -55,7 +57,7 @@ def test_stages_v2_render_md_omits_entities_section_when_empty() -> None:
 
 
 def test_stages_v2_render_md_includes_entities_section_when_present() -> None:
-    entities = [{"id": "e1", "name": "Acme", "kind": "org"}]
+    entities = [Entity(id="e1", name="Acme", kind="org")]
 
     art = render_local(_report(entities=entities))
 


### PR DESCRIPTION
Fixes #130.

## Problem

The #127 typed-return refactor made `analyze_local` / `analyze_anthropic_sdk` return `AnalysisReport` Pydantic models, and the harness passes them straight into the render stages — but `local_render` and `anthropic_sdk_render` were left dict-subscripting their input (`report["claims"]`, `report['source_sha256']`). So `harness._run_local_leg → render_local(model)` crashes:

```
TypeError: 'AnalysisReport' object is not subscriptable
```

Surfaced during a real e2e local-leg run over the locked prototype samples.

## Fix

Complete the typed migration — both render stages now accept the typed `AnalysisReport`:

- `local_render.py`: attribute access (`report.claims`, `report.entities`); the jinja template already used attribute access, so `Claim`/`Entity` objects render unchanged.
- `anthropic_sdk_render.py`: `data = report.model_dump(mode="json")` for the JSON prompt.
- Both import `AnalysisReport` under `TYPE_CHECKING` (annotation-only — not a Pydantic field).

The two render **unit tests** masked the bug by passing dicts; they now build real `AnalysisReport` models (the RED that drove the fix). The harness integration tests in `test_harness_diff_both_variants.py` — which already drive the real local render via `run_both` — were RED on `main` and are now green.

## Verification (local — pytest is not a CI gate here)

- `pytest` full suite: **165 passed, 0 failed**.
- `ruff check` on changed files: clean.
- `make lint_md` (CHANGELOG): 0 errors. `lint_links`: 11 OK.
- Real harness `_run_local_leg` on a sample PDF renders end-to-end (valid docx/pdf magic bytes).

## Out of scope (follow-ups; noted on #130)

- Undeclared `extract` vs `kreuzberg-elv2` uv-lock conflict (no `[tool.uv] conflicts`).
- No pytest gate in CI — this regression is the proof; worth adding.

Generated with Claude <noreply@anthropic.com>
