### PR TITLE
feat: keyless local-leg run — run_local + --local-only (#133)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ agents.** For technical workflows and coding standards, see
 | `make test_rerun` | Rerun only failed tests (fast TDD iteration) |
 | `make lint` | Ruff check on Python sources |
 | `make validate` | Pre-commit gate: lint + test + lint_md + lint_links |
+| `make run_local SAMPLE=path` | Run the offline local leg on one sample (no API key) |
 
 ## Code Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `harness.run_local()` + `python -m doc_pipeline_engine.harness <sample> --local-only` + `make run_local SAMPLE=…` — run the offline `local` leg with **no `ANTHROPIC_API_KEY`**. The documented run path was all-or-nothing (`run_both` fired the paid `anthropic_sdk` leg first and died without a key). README + CONTRIBUTING now document the run surface: commands, the `--local-only` / `--output-dir` / `--anthropic-sdk-model` switches, and `ANTHROPIC_API_KEY` (anthropic leg only) / `ANTHROPIC_BASE_URL` (self-hosted / gateway / Bedrock / Vertex). (#133)
 - `.github/workflows/tests.yaml` — CI gate running the documented `uv sync --extra …` install + `ruff` + `pytest` on Python 3.13 (SHA-pinned actions). Closes the gap that let the broken install (#132) and the render regression (#131) ship — no Python test/lint workflow existed before. (#132)
 - `.python-version` (`3.13`) — pin uv / Codespaces / CI to the supported full-stack Python; `requires-python>=3.11` keeps the 3.14 render-only path. (#132)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,24 @@ uv sync --extra extract --extra render --extra local           # local leg, full
 make install_local_nlp                                         # spaCy en_core_web_sm
 ```
 
+### Running the pipeline
+
+`make run_local SAMPLE=path` runs the offline `local` leg with **no API key**
+(`make help` lists every recipe). It wraps the harness entry point, which runs
+both legs when given a key:
+
+```bash
+python -m doc_pipeline_engine.harness <sample> [--local-only] [--output-dir DIR] [--anthropic-sdk-model M]
+```
+
+| Env | Purpose |
+| --- | --- |
+| `ANTHROPIC_API_KEY` | Required only for the `anthropic_sdk` leg; the `local` leg needs none |
+| `ANTHROPIC_BASE_URL` | Optional — Anthropic SDK `base_url` for a self-hosted / gateway / Bedrock / Vertex endpoint |
+
+Outputs land in `<output-dir>/<sha>/<leg>/summary.{md,docx,pdf}` (`outputs/` for
+`make run_local`; gitignored).
+
 ## Quality commands
 
 | Command | Purpose |

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 	test test_contracts test_stream test_adapters test_rerun test_fix_snapshots \
 	lint lint_md lint_links validate clean help \
 	docs docs_serve docs_index docs_contracts \
-	stream
+	stream run_local
 .DEFAULT_GOAL := help
 
 VERBOSE ?=
@@ -82,6 +82,10 @@ install_models: install_local_nlp  ## Deprecated alias for install_local_nlp; wi
 
 stream:  ## Run NDJSON stream pipeline (usage: SEED='{"root":"."}' make stream STAGES=discover)
 	echo '$(SEED)' | uv run doc-pipeline $(STAGES)
+
+run_local:  ## Run the offline local leg on one sample, no API key (usage: make run_local SAMPLE=path)
+	test -n "$(SAMPLE)" || (echo "SAMPLE required, e.g. make run_local SAMPLE=samples/legal/us/us-open-government-act-2007.pdf"; exit 2)
+	uv run python -m doc_pipeline_engine.harness $(SAMPLE) --local-only --output-dir outputs
 
 test_stream:  ## Run stream interface tests only
 	uv run pytest tests/test_stream.py -v

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ make install        # uv sync
 make test_contracts # schema round-trip tests
 ```
 
+## Run
+
+Offline `local` leg — no API key, no cloud:
+
+```bash
+make run_local SAMPLE=samples/legal/us/us-open-government-act-2007.pdf
+```
+
+Full run surface (both legs, CLI switches, `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`) → [CONTRIBUTING.md § Running the pipeline](CONTRIBUTING.md#running-the-pipeline).
+
 ## Devcontainer
 
 Reproducible dev env at `.devcontainer/devcontainer.json` (Python 3.13 + Claude Code + lint tooling). Optional system deps install on demand per use case:

--- a/src/doc_pipeline_engine/harness.py
+++ b/src/doc_pipeline_engine/harness.py
@@ -13,6 +13,7 @@ timings, costs, eval reports, and a small set of comparative axes.
 
 Usage (CLI):
     python -m doc_pipeline_engine.harness <sample_path> [--output-dir DIR]
+    python -m doc_pipeline_engine.harness <sample_path> --local-only   # no API key
 
 Both ``anthropic_sdk`` and ``extract`` extras must be installed for real runs:
     uv sync --extra extract --extra render --extra anthropic_sdk --extra local-render
@@ -164,24 +165,52 @@ def run_both(
     return report
 
 
+def run_local(
+    sample_path: Path,
+    *,
+    output_dir: Path | None = None,
+) -> LegResult:
+    """Run only the offline ``local`` leg on one sample — no ANTHROPIC_API_KEY needed.
+
+    Same discover → extract → local-leg path as :func:`run_both`, but skips the
+    paid ``anthropic_sdk`` leg entirely.
+    """
+    from doc_pipeline_engine.stages.discover import discover
+    from doc_pipeline_engine.stages.extract import extract
+
+    root = sample_path.parent
+    manifest = discover(root, glob=sample_path.name)
+    if not manifest.files:
+        raise FileNotFoundError(f"no files matched at {sample_path}")
+    file_entry = manifest.files[0]
+    bundle = extract(file_entry.model_dump(), root)
+    local = _run_local_leg(bundle)
+    if output_dir is not None:
+        _write_artifacts(Path(output_dir), file_entry.sha256, "local", local.artifacts)
+    return local
+
+
+def _leg_to_json(r: LegResult) -> dict[str, Any]:
+    """Serialise one leg result to a JSON-safe dict; artifact bytes omitted."""
+    return {
+        "variant": r.variant,
+        "contracts": [c.model_dump(mode="json") for c in r.contracts],
+        "wall_times": r.wall_times,
+        "eval_report": r.eval_report.model_dump(mode="json"),
+        "artifacts": {"md_chars": len(r.artifacts.md),
+                      "docx_bytes": len(r.artifacts.docx),
+                      "pdf_bytes": len(r.artifacts.pdf)},
+    }
+
+
 def _to_json(report: DiffReport) -> dict[str, Any]:
     """Serialise DiffReport to a JSON-safe dict; artifact bytes omitted."""
-    def leg(r: LegResult) -> dict[str, Any]:
-        return {
-            "variant": r.variant,
-            "contracts": [c.model_dump(mode="json") for c in r.contracts],
-            "wall_times": r.wall_times,
-            "eval_report": r.eval_report.model_dump(mode="json"),
-            "artifacts": {"md_chars": len(r.artifacts.md),
-                          "docx_bytes": len(r.artifacts.docx),
-                          "pdf_bytes": len(r.artifacts.pdf)},
-        }
     return {
         "sample_path": report.sample_path,
         "sample_sha256": report.sample_sha256,
         "extraction_bundle": report.extraction_bundle.model_dump(mode="json"),
-        "anthropic_sdk": leg(report.anthropic_sdk),
-        "local": leg(report.local),
+        "anthropic_sdk": _leg_to_json(report.anthropic_sdk),
+        "local": _leg_to_json(report.local),
         "axes": report.axes,
     }
 
@@ -194,7 +223,17 @@ def _cli(argv: list[str] | None = None) -> int:
     parser.add_argument("--output-dir", type=Path, default=None,
                         help="Write rendered md/docx/pdf artifacts under this dir")
     parser.add_argument("--anthropic-sdk-model", default="claude-opus-4-7")
+    parser.add_argument(
+        "--local-only",
+        action="store_true",
+        help="Run only the offline local leg (no ANTHROPIC_API_KEY needed)",
+    )
     args = parser.parse_args(argv)
+    if args.local_only:
+        leg = run_local(args.sample, output_dir=args.output_dir)
+        json.dump(_leg_to_json(leg), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
     report = run_both(
         args.sample,
         anthropic_sdk_model=args.anthropic_sdk_model,
@@ -209,4 +248,4 @@ if __name__ == "__main__":
     raise SystemExit(_cli())
 
 
-__all__ = ["DiffReport", "LegResult", "run_both"]
+__all__ = ["DiffReport", "LegResult", "run_both", "run_local"]

--- a/tests/test_harness_diff_both_variants.py
+++ b/tests/test_harness_diff_both_variants.py
@@ -26,6 +26,7 @@ from doc_pipeline_engine.harness import (
     LegResult,
     _to_json,
     run_both,
+    run_local,
 )
 from doc_pipeline_engine.models.analysis_report import AnalysisReport, AnalyzerInfo, Claim
 from doc_pipeline_engine.models.canonical_doc import CanonicalDoc, Node, TierSummary
@@ -192,3 +193,22 @@ def test_harness_run_both_raises_when_sample_missing(
 
     with pytest.raises(FileNotFoundError):
         run_both(missing)
+
+
+def test_harness_run_local_writes_local_artifacts_without_key(
+    tmp_path: Path, fake_kreuzberg: None
+) -> None:
+    # No ANTHROPIC_API_KEY and no fake_anthropic_sdk fixture: the paid leg must
+    # never run. run_local drives the real local leg only.
+    sample = _write_sample(tmp_path)
+    out = tmp_path / "outputs"
+
+    leg = run_local(sample, output_dir=out)
+
+    assert leg.variant == "local"
+    sha_dir = out / leg.contracts[0].source_sha256
+    assert (sha_dir / "local" / "summary.md").exists()
+    assert (sha_dir / "local" / "summary.docx").exists()
+    assert (sha_dir / "local" / "summary.pdf").exists()
+    # the paid anthropic_sdk leg never ran → no such artifacts
+    assert not (sha_dir / "anthropic_sdk").exists()


### PR DESCRIPTION
Closes #133.

## Problem

The documented run path `python -m doc_pipeline_engine.harness <sample>` calls `run_both`, which fires the **paid `anthropic_sdk` leg first** and dies without `ANTHROPIC_API_KEY` (`RuntimeError: anthropic_sdk leg requires ANTHROPIC_API_KEY`). Air-gapped / subscription-only users (a stated target per README + ADR-0004) had **no documented way** to run the offline `local` leg.

## Change (additive — `run_both`/`DiffReport` untouched)

- `harness.run_local(sample, *, output_dir=None)` — reuses the existing `discover` → `extract` → `_run_local_leg` → `_write_artifacts`; no new pipeline logic, no `DiffReport` API churn.
- `--local-only` CLI flag → `run_local`; `make run_local SAMPLE=path` wraps it.
- Extracted `_leg_to_json` (was an inner closure in `_to_json`) so the CLI can emit the local leg's summary; `_to_json` now reuses it.

## Docs (DRY across the hierarchy)

Makefile is the command source of truth (`make help`); CONTRIBUTING owns the run surface the Makefile can't express — the raw harness CLI switches + `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL` (self-hosted / gateway / Bedrock / Vertex); README points to CONTRIBUTING; AGENTS Key Commands gets a `make run_local` row.

## Verification

- New test `test_harness_run_local_writes_local_artifacts_without_key` (no key, no anthropic fixture → local artifacts written, paid leg never runs).
- `pytest -q` **187 passed**; `ruff` clean; `lint_md`/`lint_links` clean (incl. the README→CONTRIBUTING anchor).
- Smoke: `python -m doc_pipeline_engine.harness <pdf> --local-only` with no key → exit 0, real `summary.{md,docx,pdf}`.

Generated with Claude <noreply@anthropic.com>
