### PR TITLE
docs: local-leg example outputs (3 redistribution-clean samples)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `docs/prototype/results/2026-06-22-local-leg-examples.md` — reference `local`-leg summaries (claims + spaCy NER entities) for three redistribution-clean samples (UK-OGL contract, US-PD OPEN Government Act, US-PD NIST SP 800-63B), reproducible via `make run_local`.
 - `harness.run_local()` + `python -m doc_pipeline_engine.harness <sample> --local-only` + `make run_local SAMPLE=…` — run the offline `local` leg with **no `ANTHROPIC_API_KEY`**. The documented run path was all-or-nothing (`run_both` fired the paid `anthropic_sdk` leg first and died without a key). README + CONTRIBUTING now document the run surface: commands, the `--local-only` / `--output-dir` / `--anthropic-sdk-model` switches, and `ANTHROPIC_API_KEY` (anthropic leg only) / `ANTHROPIC_BASE_URL` (self-hosted / gateway / Bedrock / Vertex). (#133)
 - `.github/workflows/tests.yaml` — CI gate running the documented `uv sync --extra …` install + `ruff` + `pytest` on Python 3.13 (SHA-pinned actions). Closes the gap that let the broken install (#132) and the render regression (#131) ship — no Python test/lint workflow existed before. (#132)
 - `.python-version` (`3.13`) — pin uv / Codespaces / CI to the supported full-stack Python; `requires-python>=3.11` keeps the 3.14 render-only path. (#132)

--- a/docs/prototype/results/2026-06-22-local-leg-examples.md
+++ b/docs/prototype/results/2026-06-22-local-leg-examples.md
@@ -1,0 +1,71 @@
+---
+title: Local-leg example outputs
+purpose: Reference summaries the offline local leg produces via make run_local on Python 3.13
+created: 2026-06-22
+updated: 2026-06-22
+validated_links: 2026-06-22
+category: implementation
+---
+
+Deterministic outputs of the offline `local` leg (`make run_local SAMPLE=…`) on
+Python 3.13 with spaCy NER enabled. The leg is deterministic but un-tuned, so the
+entity lists include some noise (numbers and heading fragments tagged `other`).
+Reproduce with `make run_local`; full artifacts land in
+`outputs/<sha>/local/{summary.md,docx,pdf}` (gitignored). The source files are
+third-party content under various licenses — see [NOTICE](../../../NOTICE) and
+[scripts/download-samples.sh](../../../scripts/download-samples.sh) for per-file
+attribution. Only redistribution-clean sources (UK OGL / US Public Domain) are
+excerpted here.
+
+## uk-short-form-contract.docx — UK OGL v3.0
+
+`sha256 88c177fe3a74…` · 13 claims · 669 entities
+
+```markdown
+## Key Claims
+
+- 3How the Contract works18
+- 6The Buyer's obligations to the Supplier21
+- 12How much you can be held responsible for26
+
+## Entities
+
+- **New IPR** (org)
+- **Contract** (org)
+- **SUB-CONTRACTORS** (org)
+```
+
+## us-open-government-act-2007.pdf — US Public Domain
+
+`sha256 3af32df1de87…` · 22 claims · 101 entities
+
+```markdown
+## Key Claims
+
+- Public Law 110–175, 110th Congress — An Act to promote accessibility,
+  accountability, and openness in Government by strengthening section 552 of
+  title 5 (the Freedom of Information Act).
+
+## Entities
+
+- **Senate** (org)
+- **House of Representatives** (org)
+- **Congress** (org)
+- **the United States of America** (location)
+```
+
+## nist-sp800-63b.pdf — US Public Domain
+
+`sha256 ccfce7510a12…` · 105 claims · 680 entities
+
+```markdown
+## Key Claims
+
+- Digital Identity Guidelines: Authentication and Authenticator Management
+  (NIST SP 800-63B), David Temoshok et al.
+
+## Entities
+
+- **David Temoshok** (person)
+- **July 2025** (measurement)
+```


### PR DESCRIPTION
Adds reference `local`-leg outputs so users can see what `make run_local` produces without running it.

## What

`docs/prototype/results/2026-06-22-local-leg-examples.md` — claims + spaCy NER entity excerpts for three **redistribution-clean** samples, with sha / claim / entity counts:

| Sample | License | claims | entities |
| --- | --- | --- | --- |
| uk-short-form-contract.docx | UK OGL v3.0 | 13 | 669 |
| us-open-government-act-2007.pdf | US Public Domain | 22 | 101 |
| nist-sp800-63b.pdf | US Public Domain | 105 | 680 |

## Notes

- `samples/` stays **gitignored** (ADR-0010 — repo-bloat + mixed licenses). These are small *output* summaries, not the binary inputs. The "commit a redistributable sample subset" idea is tracked separately (see linked issue).
- Only UK-OGL / US-Public-Domain sources excerpted (the TI vendor datasheet was swapped out for the US-PD NIST standard to stay license-clean).
- Reproducible: `make run_local SAMPLE=…` (Python 3.13, spaCy installed).

Generated with Claude <noreply@anthropic.com>
