### PR TITLE
chore: SHA-pin all workflow actions + update pins to latest

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -18,19 +18,19 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         languages: python
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
     - name: Perform CodeQL Analysis
       id: analyze
-      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
       with:
         output: sarif-results
 

--- a/.github/workflows/generate-deploy-mkdocs-ghpages.yaml
+++ b/.github/workflows/generate-deploy-mkdocs-ghpages.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
     - name: Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         ref:
           ${{
@@ -35,11 +35,11 @@ jobs:
           }}
         fetch-depth: 0
 
-    - uses: actions/configure-pages@v5
+    - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
     # https://docs.astral.sh/uv/guides/integration/github/#caching
     - name: Install uv with cache dependency glob
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
@@ -100,11 +100,11 @@ jobs:
         fi
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
       with:
         path: "${{ env.SITE_DIR }}"
 
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v4
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 ...

--- a/.github/workflows/generate-sbom.yaml
+++ b/.github/workflows/generate-sbom.yaml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Generate SBOM
-        uses: qte77/gha-sbom-action@82becb244dc8ec442a17d5b5e171d0a384909896 # v0.1.0
+        uses: qte77/gha-sbom-action@cd873b1278a6793a99cfe199c01d603d72cca717 # v0.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           python-version: "3.13"

--- a/.github/workflows/write-llms-txt.yaml
+++ b/.github/workflows/write-llms-txt.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Generate llms.txt
         uses: qte77/gha-llms-txt-action@7cb4f03bd69a23c0e561ce76e926cadc0d3d3b9f # v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `.github/workflows/*` — SHA-pin every action and update pins to latest. Pinned the five previously **floating** tags in `generate-deploy-mkdocs-ghpages.yaml` (`actions/checkout@v4`, `configure-pages@v5`, `setup-uv@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`), which violated the repo's `sha_pinning_required` policy. Bumped existing pins: `actions/checkout` v6.0.2 → v7.0.0, `github/codeql-action` → v4 head (`8aad20d`), `qte77/gha-sbom-action` v0.1.0 → v0.1.1; the GitHub Pages chain to `configure-pages` v6.0.0 / `upload-pages-artifact` v5.0.0 / `deploy-pages` v5.0.0.
 - `tests/test_fixtures.py::test_domains_discovered` — skip when `samples/` is absent (gitignored corpus), so the suite runs in CI / fresh clones without the download. (#132)
 - `.github/dependabot.yaml` — `ignore` `kreuzberg>=4.8` so dependabot stops proposing to cross the ELv2 licence boundary ([ADR-0005](docs/adr/0005-kreuzberg-elv2-license-boundary.md)); closed stale PR #111 (which widened `<4.8` → `<4.10`). (#115)
 - `.markdownlint-cli2.jsonc` — allow `<details>`/`<summary>` (MD033 `allowed_elements`) so `make lint_md` passes on the `docs/architecture.md` collapsible. (#113)


### PR DESCRIPTION
Brings every workflow into compliance with the repo's `sha_pinning_required: true` policy and updates pins to current.

## Pinned (were floating — policy violation)

`generate-deploy-mkdocs-ghpages.yaml`: `actions/checkout@v4`, `configure-pages@v5`, `setup-uv@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4` → all SHA-pinned.

## Updated existing pins → latest

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | `de0fac2` v6.0.2 | `9c091bb` **v7.0.0** (estate-consistent) |
| `github/codeql-action/*` | `95e58e9` | `8aad20d` (**v4** head) |
| `qte77/gha-sbom-action` | `82becb2` v0.1.0 | `cd873b1` **v0.1.1** |
| `actions/configure-pages` | @v5 | `45bfe01` **v6.0.0** |
| `actions/upload-pages-artifact` | @v3 | `fc324d3` **v5.0.0** |
| `actions/deploy-pages` | @v4 | `cd2ce8f` **v5.0.0** |

`astral-sh/setup-uv` (v8.2.0), `advanced-security/dismiss-alerts` (v2.0.2), `qte77/gha-llms-txt-action` (v0.1.0) were already at latest.

## Verification / risk

- `git grep` confirms **no remaining floating `@vN`** refs across `.github/workflows/`.
- The `tests`, `CodeQL`/`Analyze`, lint, and CodeFactor checks on this PR exercise the bumped `checkout` / `codeql-action` / `setup-uv`.
- ⚠️ **Not CI-verifiable here:** the GitHub Pages chain (`configure-pages`/`upload-pages-artifact`/`deploy-pages`, bumped a major) only runs in `generate-deploy-mkdocs-ghpages.yaml` on `pull_request: closed` to main + `workflow_dispatch`. Recommend a `workflow_dispatch` run post-merge to confirm the docs deploy. They were bumped together as the current matched GitHub Pages set.

_Repo Actions allowlist already updated separately: `patterns_allowed: [astral-sh/setup-uv, advanced-security/dismiss-alerts]`._

Generated with Claude <noreply@anthropic.com>
