### PR TITLE
chore: CI/build hardening — 3.14 matrix, sed-injection fix, ruff py313, dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,4 +14,8 @@ updates:
     ignore:
       - dependency-name: "kreuzberg"
         versions: [">=4.8"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 ...

--- a/.github/workflows/generate-deploy-mkdocs-ghpages.yaml
+++ b/.github/workflows/generate-deploy-mkdocs-ghpages.yaml
@@ -64,6 +64,10 @@ jobs:
         REPO_URL=$(echo "${REPO_URL}" | sed 's|/|\\/|g')
         SITE_NAME=$(sed '1!d' README.md | sed '0,/# /{s/# //}')
         SITE_DESC=$(echo "$REPO_INFO" | jq -r .description)
+        # Escape sed replacement metacharacters (\, &, /) — SITE_NAME is README
+        # line 1 and SITE_DESC is the repo description (both editable surfaces).
+        SITE_NAME=$(printf '%s' "$SITE_NAME" | sed -e 's|[\\&/]|\\&|g')
+        SITE_DESC=$(printf '%s' "$SITE_DESC" | sed -e 's|[\\&/]|\\&|g')
         sed -i "s/<gha_sed_repo_url_here>/${REPO_URL}/g" mkdocs.yaml
         sed -i "s/<gha_sed_site_name_here>/${SITE_NAME}/g" mkdocs.yaml
         sed -i "s/<gha_sed_site_description_here>/${SITE_DESC}/g" mkdocs.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,14 +13,28 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Full stack (spaCy NER) on the supported full-fat Python.
+          - python-version: "3.13"
+            extras: "--extra extract --extra render --extra local"
+            spacy: true
+          # Render-only subset on 3.14 (spaCy has no 3.14 wheels) — guards the
+          # deliberately-supported degraded path against silent breakage.
+          - python-version: "3.14"
+            extras: "--extra extract --extra render --extra local-render"
+            spacy: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
       # Documented local-leg install — gates the extract/kreuzberg-elv2 lock conflict.
-      - run: uv sync --extra extract --extra render --extra local
-      - run: uv run python -m spacy download en_core_web_sm
+      - run: uv sync ${{ matrix.extras }}
+      - if: ${{ matrix.spacy }}
+        run: uv run python -m spacy download en_core_web_sm
       - run: uv run ruff check .
       - run: uv run pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `harness.run_local()` + `python -m doc_pipeline_engine.harness <sample> --local-only` + `make run_local SAMPLE=…` — run the offline `local` leg with **no `ANTHROPIC_API_KEY`**. The documented run path was all-or-nothing (`run_both` fired the paid `anthropic_sdk` leg first and died without a key). README + CONTRIBUTING now document the run surface: commands, the `--local-only` / `--output-dir` / `--anthropic-sdk-model` switches, and `ANTHROPIC_API_KEY` (anthropic leg only) / `ANTHROPIC_BASE_URL` (self-hosted / gateway / Bedrock / Vertex). (#133)
 - `.github/workflows/tests.yaml` — CI gate running the documented `uv sync --extra …` install + `ruff` + `pytest` on Python 3.13 (SHA-pinned actions). Closes the gap that let the broken install (#132) and the render regression (#131) ship — no Python test/lint workflow existed before. (#132)
 - `.python-version` (`3.13`) — pin uv / Codespaces / CI to the supported full-stack Python; `requires-python>=3.11` keeps the 3.14 render-only path. (#132)
+- `.github/dependabot.yaml` — add a `github-actions` ecosystem stanza (weekly) to auto-PR action-SHA bumps; every used action is already on the repo's Actions allowlist.
 
 ### Changed
 
 - `.github/workflows/*` — SHA-pin every action and update pins to latest. Pinned the five previously **floating** tags in `generate-deploy-mkdocs-ghpages.yaml` (`actions/checkout@v4`, `configure-pages@v5`, `setup-uv@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`), which violated the repo's `sha_pinning_required` policy. Bumped existing pins: `actions/checkout` v6.0.2 → v7.0.0, `github/codeql-action` → v4 head (`8aad20d`), `qte77/gha-sbom-action` v0.1.0 → v0.1.1; the GitHub Pages chain to `configure-pages` v6.0.0 / `upload-pages-artifact` v5.0.0 / `deploy-pages` v5.0.0.
+- `.github/workflows/tests.yaml` — run the suite on a Python **3.13 + 3.14** matrix; the 3.14 row installs the render-only `local-render` subset (no spaCy) so the deliberately-supported degraded path can't silently break.
+- `pyproject.toml` `[tool.ruff] target-version` `py311` → `py313` (matches `.python-version`; zero new violations).
 - `tests/test_fixtures.py::test_domains_discovered` — skip when `samples/` is absent (gitignored corpus), so the suite runs in CI / fresh clones without the download. (#132)
 - `.github/dependabot.yaml` — `ignore` `kreuzberg>=4.8` so dependabot stops proposing to cross the ELv2 licence boundary ([ADR-0005](docs/adr/0005-kreuzberg-elv2-license-boundary.md)); closed stale PR #111 (which widened `<4.8` → `<4.10`). (#115)
 - `.markdownlint-cli2.jsonc` — allow `<details>`/`<summary>` (MD033 `allowed_elements`) so `make lint_md` passes on the `docs/architecture.md` collapsible. (#113)
@@ -58,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restrictions (no managed-service offering, attribution required). Default
   install path stays Apache-2.0-clean. See
   [ADR-0005](docs/adr/0005-kreuzberg-elv2-license-boundary.md). Resolves #76.
+- `generate-deploy-mkdocs-ghpages.yaml` — escape `SITE_NAME` (README line 1) and `SITE_DESC` (repo `.description`) before splicing them into `sed -i`, closing a sed-injection where `/`, `&`, or `\` in those editable fields could corrupt or inject into the generated `mkdocs.yaml`.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ addopts = "-ra -q"
 
 [tool.ruff]
 line-length = 100
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 # D rules enforce docstring presence so mkdocstrings has something to render.


### PR DESCRIPTION
Small CI/build hardening cluster from the post-task ROI review.

## Changes
- **`tests.yaml` — Python 3.13 + 3.14 matrix.** The 3.14 row installs the render-only `local-render` subset (no spaCy) so the **deliberately-supported degraded 3.14 path** is gated against silent breakage (it's what bit us this session). `fail-fast: false`; spaCy model download is `if: matrix.python-version == '3.13'`.
- **`generate-deploy-mkdocs-ghpages.yaml` — sed-injection fix (security).** `SITE_NAME` (README line 1) and `SITE_DESC` (GitHub API `.description`) were spliced **unescaped** into `sed -i "s/…/…/"` — a `/` already silently breaks the docs deploy and `&`/`\` inject. Now escaped via `sed -e 's|[\\&/]|\\&|g'` before use.
- **`pyproject.toml` `[tool.ruff] target-version` `py311` → `py313`** — matches `.python-version`; `ruff check` confirmed **zero** new violations.
- **`.github/dependabot.yaml` — `github-actions` ecosystem stanza** (weekly) to auto-PR action-SHA bumps (automates the manual bumps from #143; every used action is already on the allowlist).

## Verification
- `ruff check .` clean (py313); `pytest -q` **165 passed**; `lint_md` clean.
- The 3.13 **and** 3.14 matrix jobs run on this PR.
- ⚠️ The mkdocs sed-fix isn't CI-exercisable (Deploy Docs runs on PR-close / `workflow_dispatch`) — recommend one manual **"Deploy Docs" dispatch** post-merge (also confirms the #143 Pages major-bump).

Generated with Claude <noreply@anthropic.com>
